### PR TITLE
Fix for another unhandled 'KeyError' exception

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -801,9 +801,10 @@ class Gmail(object):
 
         elif payload['mimeType'].startswith('multipart'):
             ret = []
-            for part in payload['parts']:
-                ret.extend(self._evaluate_message_payload(part, user_id, msg_id,
-                                                          attachments))
+            if 'parts' in payload:
+                for part in payload['parts']:
+                    ret.extend(self._evaluate_message_payload(part, user_id, msg_id,
+                                                              attachments))
             return ret
 
         return []


### PR DESCRIPTION
This commit fixes an additional KeyError bug in gmail.py.

Explanation of the bug: in rare cases where a _"payload"_ dict object is missing a _'parts'_ key, an unhandled KeyError exception is caused by the `for part in payload['parts']` statement under the `_evaluate_message_payload` function.

Fix: This commit fixes the KeyError bug by adding the `if 'parts' in payload` statement, ensuring that the key exists in the payload dictionary before proceeding.