### PR TITLE
Fix for ZeroDivisionError

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -601,6 +601,10 @@ class Gmail(object):
             math.ceil(len(message_refs) / target_msgs_per_thread),
             max_num_threads
         )
+        # Ensure there is at least one thread (prevents a ZeroDivisionError)
+        if num_threads < 1:
+            num_threads = 1
+
         batch_size = math.ceil(len(message_refs) / num_threads)
         message_lists = [None] * num_threads
 


### PR DESCRIPTION
This commit fixes a ZeroDivisionError in gmail.py

Explanation of the bug: The multithreading in gmail.py aims to use the minimal number of needed threads, however in some cases that minimal number can be zero. This causes a `ZeroDivisionError: division by zero` exception in the calculation `batch_size = math.ceil(len(message_refs) / num_threads)` in line 604.

Fix: This commit fixes the ZeroDivisionError bug by an if statement that ensures the number of threads is at least 1. If the number of threads is less than 1, then it is changed to 1.