### PR TITLE
Explicitly set an empty argument list to the oauth2client cmdline

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -83,7 +83,8 @@ class Gmail(object):
                 flow = client.flow_from_clientsecrets(
                     self.client_secret_file, self._SCOPES
                 )
-                self.creds = tools.run_flow(flow, store)
+                flags = tools.argparser.parse_args([])
+                self.creds = tools.run_flow(flow, store, flags)
 
             self._service = build(
                 'gmail', 'v1', http=self.creds.authorize(Http()),


### PR DESCRIPTION
Calling simplegmail from another command-line
tool using argparse, would pass the current options unrelated
of the command to the run_flow call and fail.

The change set empty flags before calling run_flow