### PR TITLE
Add CC & BCC to message object

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -701,6 +701,8 @@ class Gmail(object):
             recipient = ''
             subject = ''
             msg_hdrs = {}
+            cc = ''
+            bcc = ''
             for hdr in headers:
                 if hdr['name'].lower() == 'date':
                     try:
@@ -713,6 +715,10 @@ class Gmail(object):
                     recipient = hdr['value']
                 elif hdr['name'].lower() == 'subject':
                     subject = hdr['value']
+                elif hdr['name'].lower() == 'cc':
+                    cc = hdr['value']
+                elif hdr['name'].lower() == 'bcc':
+                    bcc = hdr['value']
 
                 msg_hdrs[hdr['name']] = hdr['value']
 
@@ -742,7 +748,7 @@ class Gmail(object):
 
             return Message(self.service, self.creds, user_id, msg_id,
                 thread_id, recipient, sender, subject, date, snippet,
-                plain_msg, html_msg, label_ids, attms, msg_hdrs)
+                plain_msg, html_msg, label_ids, attms, msg_hdrs, cc, bcc)
 
     def _evaluate_message_payload(
         self,

--- a/simplegmail/message.py
+++ b/simplegmail/message.py
@@ -36,6 +36,9 @@ class Message(object):
         html: the HTML contents of the message. Default None.
         label_ids: the ids of labels associated with this message. Default [].
         attachments: a list of attachments for the message. Default [].
+        headers: a dict of header values. Default {}
+        cc: who the message was CCd to.
+        bcc: who the message was BCCd to.
 
     Attributes:
         _service (googleapiclient.discovery.Resource): the Gmail service object.
@@ -50,6 +53,9 @@ class Message(object):
         html (str): the HTML contents of the message.
         label_ids (List[str]): the ids of labels associated with this message.
         attachments (List[Attachment]): a list of attachments for the message.
+        headers (dict): a dict of header values.
+        cc (str): who the message was CCd to.
+        bcc (str): who the message was BCCd to.
 
     """
 
@@ -69,7 +75,9 @@ class Message(object):
         html: Optional[str] = None,
         label_ids: Optional[List[str]] = None,
         attachments: Optional[List[Attachment]] = None,
-        headers: Optional[dict] = None
+        headers: Optional[dict] = None,
+        cc: str = '',
+        bcc: str = ''
     ) -> None:
         self._service = service
         self.creds = creds
@@ -86,6 +94,8 @@ class Message(object):
         self.label_ids = label_ids if label_ids is not None else []
         self.attachments = attachments if attachments is not None else []
         self.headers = headers if headers else {}
+        self.cc = cc
+        self.bcc = bcc
 
     @property
     def service(self) -> 'googleapiclient.discovery.Resource':


### PR DESCRIPTION
Example usage:
```python
from simplegmail import Gmail

gmail = Gmail()

# Unread messages in your inbox
messages = gmail.get_unread_inbox()

# Starred messages
messages = gmail.get_starred_messages()

# ...and many more easy to use functions can be found in gmail.py!

# Print them out!
for message in messages:
    print("To: " + message.recipient)
    print("From: " + message.sender)
    print("Cc: " + message.cc)
    print("Bcc: " + message.bcc)
    print("Subject: " + message.subject)
    print("Date: " + message.date)
    print("Preview: " + message.snippet)
    
    print("Message Body: " + message.plain)  # or message.html
```