### PR TITLE
Add new fields to label

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -569,7 +569,16 @@ class Gmail(object):
             raise error
 
         else:
-            labels = [Label(name=x['name'], id=x['id']) for x in res['labels']]
+            labels = [
+                Label(
+                    name=x["name"],
+                    id=x["id"],
+                    type=x["type"],
+                    messageListVisibility=x.get("messageListVisibility", ""),
+                    labelListVisibility=x.get("labelListVisibility", ""),
+                )
+                for x in res["labels"]
+            ]
             return labels
 
     def _get_messages_from_refs(

--- a/simplegmail/label.py
+++ b/simplegmail/label.py
@@ -10,22 +10,37 @@ class Label:
     """
     A Gmail label object.
 
-    This class should not typically be constructed directly but rather returned 
+    This class should not typically be constructed directly but rather returned
     from Gmail.list_labels().
-    
+
     Args:
         name: The name of the Label.
         id: The ID of the label.
+        type: The owner type for the label.
+        messageListVisibility: The visibility of messages with this label.
+        labelListVisibility: The visibility of the label.
 
     Attributes:
         name (str): The name of the Label.
         id (str): The ID of the label.
+        type (str): The owner type for the label.
+        messageListVisibility (str): The visibility of messages with this label.
+        labelListVisibility (str): The visibility of the label.
 
     """
 
-    def __init__(self, name: str, id: str) -> None:
+    def __init__(
+            self, name: str,
+            id: str,
+            type: str,
+            messageListVisibility: str,
+            labelListVisibility: str
+        ) -> None:
         self.name = name
         self.id = id
+        self.type = type
+        self.messageListVisibility = messageListVisibility
+        self.labelListVisibility = labelListVisibility
 
     def __repr__(self) -> str:
         return f'Label(name={self.name!r}, id={self.id!r})'
@@ -46,16 +61,17 @@ class Label:
             return False
 
 
-INBOX      = Label('INBOX', 'INBOX')
-SPAM       = Label('SPAM', 'SPAM')
-TRASH      = Label('TRASH', 'TRASH')
-UNREAD     = Label('UNREAD', 'UNREAD')
-STARRED    = Label('STARRED', 'STARRED')
-SENT       = Label('SENT', 'SENT')
-IMPORTANT  = Label('IMPORTANT', 'IMPORTANT')
-DRAFT      = Label('DRAFT', 'DRAFT')
-PERSONAL   = Label('CATEGORY_PERSONAL', 'CATEGORY_PERSONAL')
-SOCIAL     = Label('CATEGORY_SOCIAL', 'CATEGORY_SOCIAL')
-PROMOTIONS = Label('CATEGORY_PROMOTIONS', 'CATEGORY_PROMOTIONS')
-UPDATES    = Label('CATEGORY_UPDATES', 'CATEGORY_UPDATES')
-FORUMS     = Label('CATEGORY_FORUMS', 'CATEGORY_FORUMS')
+INBOX      = Label('INBOX', 'INBOX', 'system', '', '')
+SPAM       = Label('SPAM', 'SPAM', 'system', '', '')
+TRASH      = Label('TRASH', 'TRASH', 'system', '', '')
+UNREAD     = Label('UNREAD', 'UNREAD', 'system', '', '')
+STARRED    = Label('STARRED', 'STARRED', 'system', '', '')
+SENT       = Label('SENT', 'SENT', 'system', '', '')
+IMPORTANT  = Label('IMPORTANT', 'IMPORTANT', 'system', '', '')
+DRAFT      = Label('DRAFT', 'DRAFT', 'system', '', '')
+CHAT       = Label('CHAT', 'CHAT', 'system', '', '')
+PERSONAL   = Label('CATEGORY_PERSONAL', 'CATEGORY_PERSONAL', 'system', '', '')
+SOCIAL     = Label('CATEGORY_SOCIAL', 'CATEGORY_SOCIAL', 'system', '', '')
+PROMOTIONS = Label('CATEGORY_PROMOTIONS', 'CATEGORY_PROMOTIONS', 'system', '', '')
+UPDATES    = Label('CATEGORY_UPDATES', 'CATEGORY_UPDATES', 'system', '', '')
+FORUMS     = Label('CATEGORY_FORUMS', 'CATEGORY_FORUMS', 'system', '', '')


### PR DESCRIPTION
This adds all the fields returned by the labels.list API.

Example:
```python
gmail = simplegmail.Gmail()

labels = gmail.list_labels()
for label in labels:
    print(label.name, label.id, label.type, label.messageListVisibility, label.labelListVisibility)
```

It also adds a predefined CHAT label, which was missing.
