### PR TITLE
Fix issue #55

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -884,18 +884,16 @@ class Gmail(object):
 
             msg_html += "<br /><br />" + account_sig
 
-        attach_plain = MIMEMultipart('alternative') if attachments else msg
-        attach_html = MIMEMultipart('related') if attachments else msg
+        text_part = MIMEMultipart('alternative') if attachments else msg
 
         if msg_plain:
-            attach_plain.attach(MIMEText(msg_plain, 'plain'))
+            text_part.attach(MIMEText(msg_plain, 'plain'))
 
         if msg_html:
-            attach_html.attach(MIMEText(msg_html, 'html'))
+            text_part.attach(MIMEText(msg_html, 'html'))
 
         if attachments:
-            attach_plain.attach(attach_html)
-            msg.attach(attach_plain)
+            msg.attach(text_part)
 
             self._ready_message_with_attachments(msg, attachments)
 


### PR DESCRIPTION
Hello. This is my first contribution to open source. I have addressed the issue #55 by unification of message text (plain or html) into a single 'alternative' Multipart MIME, to which text and html MIMEs could be attached. Now the plain text will not disappear when attachments exist. The structure of the whole message MIME would be:
```
multipart/mixed
  multipart/alternative
    text/plain
    text/html
  attachment1_type/subtype
  ...
```