### PR TITLE
Enables Using Environment Variable for Authorization - Issue #49

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -69,6 +69,7 @@ class Gmail(object):
         access_type: str = 'offline',
         noauth_local_webserver: bool = False,
         _creds: Optional[client.OAuth2Credentials] = None,
+        use_envvars: bool = False
     ) -> None:
         self.client_secret_file = client_secret_file
         self.creds_file = creds_file
@@ -79,6 +80,13 @@ class Gmail(object):
             # completes for the first time.
             if _creds:
                 self.creds = _creds
+            elif use_envvars:
+                # This requires that the environment variable 
+                # 'SIMPLEGMAIL_CREDENTIALS' be set to an already authorized
+                # gmail_token.json contents. This gives the refresh token 
+                # that can be used indefinitely until revoked.
+                self.creds = client.OAuth2Credentials.from_json(
+                    os.environ.get('SIMPLEGMAIL_CREDENTIALS'))
             else:
                 store = file.Storage(self.creds_file)
                 self.creds = store.get()


### PR DESCRIPTION
Solves #49 

Added an init option to the Gmail class to respect environment variable SIMPLEGMAIL_CREDENTIALS as an alternative to having the gmail_token.json. 

## Why: 
This provides a solution for dockerizing a project using secrets. While you can mount a secret as a file within k8s and updating that file won't affect the pods operation this is not true with docker. This allows you to set the variable and the container build and manage the auth token file without reauthorization or having to give write permissions to each container sharing the same bind mount.

## Use:
set the environment variable in the shell
```
export SIMPLEGMAIL_CREDENTIALS=$(cat gmail_token.json)  
```

```
# script.py
from simplegmail import Gmail

gmail = Gmail(use_envvars=True)

```
