### PR TITLE
Expose internal date from google

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md
+
+## Development Process
+
+**TDD is mandatory.** All code changes must follow the red → green → refactor → package cycle:
+
+1. **Red** — Write a failing test first that describes the desired behavior. Run it and confirm it fails for the expected reason before writing any implementation code.
+2. **Green** — Write the minimum implementation needed to make the test pass. Run the test suite and confirm it passes.
+3. **Refactor** — Clean up the implementation and tests while keeping the whole suite green.
+4. **Package** — Build a pip distribution package (`uv build`, which writes the sdist and wheel to `dist/`). And then display the package name and details.
+
+Rules:
+
+- Never write implementation code before a failing test exists for it.
+- Never commit with failing tests.
+- Bug fixes start with a test that reproduces the bug.
+
+## Tooling
+
+- **uv** is the package manager. The virtualenv lives in `.venv/`; install dependencies with `uv pip install ...`.
+- **pytest** is the test runner. Tests live in `tests/`; run them with `.venv/bin/python -m pytest tests/`.
+- Distribution packages are built with `uv build`.
+
+## Project Layout
+
+- `simplegmail/` — package source (`gmail.py` is the main client; `message.py`, `attachment.py`, `label.py`, `query.py` are supporting modules)
+- `tests/` — test suite

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ for message in messages:
     print("To: " + message.recipient)
     print("From: " + message.sender)
     print("Subject: " + message.subject)
-    print("Date: " + message.date)
+    print("Date: " + message.headerDate)  # from the message's Date header
+    # message.internalDate is Gmail's received timestamp (epoch milliseconds)
     print("Preview: " + message.snippet)
     
     print("Message Body: " + message.plain)  # or message.html
@@ -348,6 +349,11 @@ What to watch out for:
 - **`get_unread_inbox()` now honors its `attachments` argument**, which was
   previously ignored due to a bug.
 
+- **`message.date` is now `message.headerDate`.** This is a breaking rename:
+  reading `message.date` raises `AttributeError`. The value is unchanged (the
+  parsed `Date` header). A new `message.internalDate` attribute also exposes
+  Gmail's internal received timestamp in epoch milliseconds.
+
 ## Feedback
 
 If there is functionality you'd like to see added, or any bugs in this project,
@@ -375,3 +381,14 @@ messages are available almost immediately, memory use is bounded to a single
 page, requests are spread out over the lifetime of the iteration instead of
 issued all at once, and the new `page_size` argument (1-500, default 100)
 controls how many messages are fetched per page.
+
+Other changes:
+
+- **BREAKING: `Message.date` has been renamed to `Message.headerDate`.** Any
+  code reading `message.date` will now raise `AttributeError` and must be
+  updated to `message.headerDate`. The value itself is unchanged: the date
+  parsed from the message's `Date` header, localized to your timezone.
+- **New: `Message.internalDate`** exposes Gmail's internal received timestamp
+  in milliseconds since the epoch as an `int` (`None` if the API omits it).
+  Unlike `headerDate`, which comes from a sender-controlled header, this is
+  Gmail's own metadata — prefer it for sorting or comparing messages.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Currently Supported Behavior:
 - Modifying message labels (includes marking as read/unread, important/not 
   important, starred/unstarred, trash/untrash, inbox/archive)
 
+> **⚠️ Breaking change in 5.0:** `get_messages()` and all other message
+> retrieval methods now return a lazy, single-pass iterator instead of a list.
+> Wrap the result in `list(...)` to restore the old behavior. See
+> [Migrating from 4.x](#migrating-from-4x).
+
 ## Table of Contents
 
 - [Getting Started](#getting-started)
@@ -28,6 +33,7 @@ Currently Supported Behavior:
     - [Downloading attachments](#downloading-attachments)
     - [Retrieving messages with queries](#retrieving-messages-advanced-with-queries)
     - [Retrieving messages with more advanced queries](#retrieving-messages-more-advanced-with-more-queries)
+- [Migrating from 4.x](#migrating-from-4x)
 - [Feedback](#feedback)
 
 ## Getting Started
@@ -127,6 +133,11 @@ It couldn't be easier!
 
 ### Retrieving messages:
 
+Retrieval methods return a lazy iterator: messages are downloaded one page at
+a time (100 per page by default, tunable with `page_size`) as you loop over
+it. An iterator can only be consumed once — wrap it in `list(...)` if you need
+everything in memory at once.
+
 ```python
 from simplegmail import Gmail
 
@@ -158,7 +169,8 @@ from simplegmail import Gmail
 
 gmail = Gmail()
 
-messages = gmail.get_unread_inbox()
+# list() fetches everything eagerly, restoring pre-5.0 behavior
+messages = list(gmail.get_unread_inbox())
 
 message_to_read = messages[0]
 message_to_read.mark_as_read()
@@ -189,10 +201,10 @@ labels = gmail.list_labels()
 # To find a label by the name that you know (just an example):
 finance_label = list(filter(lambda x: x.name == 'Finance', labels))[0]
 
-messages = gmail.get_unread_inbox()
+# Lazily fetch just the newest unread message (only one message is downloaded)
+message = next(gmail.get_unread_inbox(page_size=1))
 
 # We can add/remove a label
-message = messages[0]
 message.add_label(finance_label) 
 
 # We can "move" a message from one label to another
@@ -208,9 +220,8 @@ from simplegmail import Gmail
 
 gmail = Gmail()
 
-messages = gmail.get_unread_inbox()
+message = next(gmail.get_unread_inbox(page_size=1))
 
-message = messages[0]
 if message.attachments:
     for attm in message.attachments:
         print('File: ' + attm.filename)
@@ -283,6 +294,58 @@ messages = gmail.get_messages(query=construct_query(query_params_1, query_params
 ```
 
 For more on what you can do with queries, read the docstring for `construct_query()` in `query.py`.
+
+## Migrating from 4.x
+
+As of 5.0, `get_messages()` and every other message retrieval method
+(`get_unread_inbox()`, `get_starred_messages()`, etc.) return a lazy
+`Iterator[Message]` instead of a `List[Message]`. Messages are fetched from
+the Gmail API one page at a time, as you consume the iterator — so getting the
+first message of a large mailbox is fast, and memory use stays bounded.
+
+What to watch out for:
+
+- **Indexing, slicing, and `len()` no longer work.** Wrap the result in
+  `list(...)` to restore the old behavior exactly:
+
+  ```python
+  messages = list(gmail.get_messages())
+  ```
+
+- **The iterator is single-pass.** Iterating a second time yields nothing.
+  Store the result of `list(...)` if you need multiple passes.
+
+- **Truthiness checks silently break.** An iterator is always truthy, even
+  when there are no matching messages. Instead of `if not messages:`, use:
+
+  ```python
+  message = next(gmail.get_messages(query=...), None)
+  if message is None:
+      print("No matches!")
+  ```
+
+- **Errors can now occur while iterating.** The initial call still raises
+  `HttpError` immediately if listing the first page fails (bad credentials,
+  an invalid label), but errors while downloading messages — including those
+  on the first page — and errors listing later pages are raised from the loop
+  itself. Wrap the `for` loop (not just the call) in `try/except` if you
+  handle these. A failed iterator cannot be resumed.
+
+- **`page_size` controls fetch granularity** (1–500, default 100). Use a
+  small value when you only want the first few messages, e.g.
+  `next(gmail.get_unread_inbox(page_size=1))`, or combine with
+  `itertools.islice` for the first N:
+
+  ```python
+  from itertools import islice
+  newest_ten = list(islice(gmail.get_messages(page_size=10), 10))
+  ```
+
+- **Invalid `attachments` values now raise `ValueError`.** Previously a typo
+  like `attachments='referance'` silently behaved like `'download'`.
+
+- **`get_unread_inbox()` now honors its `attachments` argument**, which was
+  previously ignored due to a bug.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Currently Supported Behavior:
     - [Retrieving messages with more advanced queries](#retrieving-messages-more-advanced-with-more-queries)
 - [Migrating from 4.x](#migrating-from-4x)
 - [Feedback](#feedback)
+- [Release Notes](#release-notes)
 
 ## Getting Started
 
@@ -351,3 +352,26 @@ What to watch out for:
 
 If there is functionality you'd like to see added, or any bugs in this project,
 please let me know by posting an issue or submitting a pull request!
+
+## Release Notes
+
+### 5.0.0
+
+`get_messages()` and the other message retrieval methods previously fetched
+every page of matching message references and downloaded every message before
+returning. On large mailboxes this meant a single call could take a very long
+time and had to hold every `Message` in memory at once, which could cause
+out-of-memory errors. Downloading the entire mailbox in one burst could also
+exceed the Gmail API's per-user rate limits, failing the whole call with an
+error like:
+
+```
+googleapiclient.errors.HttpError: <HttpError 403 when requesting https://gmail.googleapis.com/gmail/v1/users/me/messages/1822775953ea0028?alt=json returned "Quota exceeded for quota metric 'Queries' and limit 'Queries per minute per user' of service 'gmail.googleapis.com' for consumer 'project_number:5513285XXXX'.". Details: "[{'message': "Quota exceeded for quota metric 'Queries' and limit 'Queries per minute per user' of service 'gmail.googleapis.com' for consumer 'project_number:5513285XXXX'.", 'domain': 'usageLimits', 'reason': 'rateLimitExceeded'}]">
+```
+
+These methods now return a lazy iterator that fetches messages one page at a
+time, on demand (see [Migrating from 4.x](#migrating-from-4x)): the first
+messages are available almost immediately, memory use is bounded to a single
+page, requests are spread out over the lifetime of the iteration instead of
+issued all at once, and the new `page_size` argument (1-500, default 100)
+controls how many messages are fetched per page.

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ import setuptools
 
 setuptools.setup(
     name="simplegmail",
-    version="4.1.1",
+    version="5.0.0",
     url="https://github.com/jeremyephron/simplegmail",
     author="Jeremy Ephron",
     author_email="jeremye@cs.stanford.edu",
     description="A simple Python API client for Gmail.",
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     packages=setuptools.find_packages(),
     install_requires=[

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -19,7 +19,7 @@ import mimetypes
 import os
 import re
 import threading
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from bs4 import BeautifulSoup
 import dateutil.parser as parser
@@ -181,8 +181,9 @@ class Gmail(object):
         user_id: str = 'me',
         labels: Optional[List[Label]] = None,
         query: str = '',
-        attachments: str = 'reference'
-    ) -> List[Message]:
+        attachments: str = 'reference',
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
         Gets unread messages from your inbox.
 
@@ -196,13 +197,23 @@ class Gmail(object):
                 information but does not download the data, and 'download' which
                 downloads the attachment data to store locally. Default
                 'reference'.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -210,7 +221,8 @@ class Gmail(object):
             labels = []
 
         labels.append(label.INBOX)
-        return self.get_unread_messages(user_id, labels, query)
+        return self.get_unread_messages(user_id, labels, query, attachments,
+                                        page_size=page_size)
 
     def get_starred_messages(
         self,
@@ -218,8 +230,9 @@ class Gmail(object):
         labels: Optional[List[Label]] = None,
         query: str = '',
         attachments: str = 'reference',
-        include_spam_trash: bool = False
-    ) -> List[Message]:
+        include_spam_trash: bool = False,
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
         Gets starred messages from your account.
 
@@ -234,13 +247,23 @@ class Gmail(object):
                 downloads the attachment data to store locally. Default
                 'reference'.
             include_spam_trash: Whether to include messages from spam or trash.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -249,7 +272,7 @@ class Gmail(object):
 
         labels.append(label.STARRED)
         return self.get_messages(user_id, labels, query, attachments,
-                                 include_spam_trash)
+                                 include_spam_trash, page_size=page_size)
 
     def get_important_messages(
         self,
@@ -257,8 +280,9 @@ class Gmail(object):
         labels: Optional[List[Label]] = None,
         query: str = '',
         attachments: str = 'reference',
-        include_spam_trash: bool = False
-    ) -> List[Message]:
+        include_spam_trash: bool = False,
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
         Gets messages marked important from your account.
 
@@ -273,13 +297,23 @@ class Gmail(object):
                 downloads the attachment data to store locally. Default
                 'reference'.
             include_spam_trash: Whether to include messages from spam or trash.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -288,7 +322,7 @@ class Gmail(object):
 
         labels.append(label.IMPORTANT)
         return self.get_messages(user_id, labels, query, attachments,
-                                 include_spam_trash)
+                                 include_spam_trash, page_size=page_size)
 
     def get_unread_messages(
         self,
@@ -296,8 +330,9 @@ class Gmail(object):
         labels: Optional[List[Label]] = None,
         query: str = '',
         attachments: str = 'reference',
-        include_spam_trash: bool = False
-    ) -> List[Message]:
+        include_spam_trash: bool = False,
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
         Gets unread messages from your account.
 
@@ -312,13 +347,23 @@ class Gmail(object):
                 downloads the attachment data to store locally. Default
                 'reference'.
             include_spam_trash: Whether to include messages from spam or trash.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -327,7 +372,7 @@ class Gmail(object):
 
         labels.append(label.UNREAD)
         return self.get_messages(user_id, labels, query, attachments,
-                                 include_spam_trash)
+                                 include_spam_trash, page_size=page_size)
 
     def get_drafts(
         self,
@@ -335,8 +380,9 @@ class Gmail(object):
         labels: Optional[List[Label]] = None,
         query: str = '',
         attachments: str = 'reference',
-        include_spam_trash: bool = False
-    ) -> List[Message]:
+        include_spam_trash: bool = False,
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
         Gets drafts saved in your account.
 
@@ -351,13 +397,23 @@ class Gmail(object):
                 downloads the attachment data to store locally. Default
                 'reference'.
             include_spam_trash: Whether to include messages from spam or trash.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -366,7 +422,7 @@ class Gmail(object):
 
         labels.append(label.DRAFT)
         return self.get_messages(user_id, labels, query, attachments,
-                                 include_spam_trash)
+                                 include_spam_trash, page_size=page_size)
 
     def get_sent_messages(
         self,
@@ -374,8 +430,9 @@ class Gmail(object):
         labels: Optional[List[Label]] = None,
         query: str = '',
         attachments: str = 'reference',
-        include_spam_trash: bool = False
-    ) -> List[Message]:
+        include_spam_trash: bool = False,
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
         Gets sent messages from your account.
 
@@ -390,13 +447,23 @@ class Gmail(object):
                 downloads the attachment data to store locally. Default
                 'reference'.
             include_spam_trash: Whether to include messages from spam or trash.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -405,15 +472,16 @@ class Gmail(object):
 
         labels.append(label.SENT)
         return self.get_messages(user_id, labels, query, attachments,
-                                 include_spam_trash)
+                                 include_spam_trash, page_size=page_size)
 
     def get_trash_messages(
         self,
         user_id: str = 'me',
         labels: Optional[List[Label]] = None,
         query: str = '',
-        attachments: str = 'reference'
-    ) -> List[Message]:
+        attachments: str = 'reference',
+        page_size: int = 100
+    ) -> Iterator[Message]:
 
         """
         Gets messages in your trash from your account.
@@ -428,13 +496,23 @@ class Gmail(object):
                 information but does not download the data, and 'download' which
                 downloads the attachment data to store locally. Default
                 'reference'.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -442,15 +520,17 @@ class Gmail(object):
             labels = []
 
         labels.append(label.TRASH)
-        return self.get_messages(user_id, labels, query, attachments, True)
+        return self.get_messages(user_id, labels, query, attachments, True,
+                                 page_size=page_size)
 
     def get_spam_messages(
         self,
         user_id: str = 'me',
         labels: Optional[List[Label]] = None,
         query: str = '',
-        attachments: str = 'reference'
-    ) -> List[Message]:
+        attachments: str = 'reference',
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
         Gets messages marked as spam from your account.
 
@@ -464,13 +544,23 @@ class Gmail(object):
                 information but does not download the data, and 'download' which
                 downloads the attachment data to store locally. Default
                 'reference'.
+            page_size: The number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
 
@@ -479,7 +569,8 @@ class Gmail(object):
             labels = []
 
         labels.append(label.SPAM)
-        return self.get_messages(user_id, labels, query, attachments, True)
+        return self.get_messages(user_id, labels, query, attachments, True,
+                                 page_size=page_size)
 
     def get_messages(
         self,
@@ -487,10 +578,11 @@ class Gmail(object):
         labels: Optional[List[Label]] = None,
         query: str = '',
         attachments: str = 'reference',
-        include_spam_trash: bool = False
-    ) -> List[Message]:
+        include_spam_trash: bool = False,
+        page_size: int = 100
+    ) -> Iterator[Message]:
         """
-        Gets messages from your account.
+        Gets messages from your account, lazily, one page at a time.
 
         Args:
             user_id: the user's email address. Default 'me', the authenticated
@@ -503,15 +595,36 @@ class Gmail(object):
                 downloads the attachment data to store locally. Default
                 'reference'.
             include_spam_trash: whether to include messages from spam or trash.
+            page_size: the number of message references fetched per API page,
+                between 1 and 500. Smaller values yield the first message
+                sooner; larger values scan large mailboxes with fewer
+                requests. Default 100.
 
         Returns:
-            A list of message objects.
+            An iterator over Message objects, fetched lazily in pages of
+            `page_size`. The iterator can only be consumed once; wrap it in
+            `list()` to fetch everything eagerly.
 
         Raises:
+            ValueError: An invalid value was provided for `attachments` or
+                `page_size`.
             googleapiclient.errors.HttpError: There was an error executing the
-                HTTP request.
+                HTTP request. Errors listing the first page of results are
+                raised by this call; all other errors (downloading messages
+                and listing later pages) are raised while iterating.
 
         """
+
+        if attachments not in ('ignore', 'reference', 'download'):
+            raise ValueError(
+                f"Unrecognized option '{attachments}' for attachments, "
+                "expected one of 'ignore', 'reference', or 'download'."
+            )
+
+        if not 1 <= page_size <= 500:
+            raise ValueError(
+                f"page_size must be between 1 and 500, got {page_size}."
+            )
 
         if labels is None:
             labels = []
@@ -525,31 +638,71 @@ class Gmail(object):
                 userId=user_id,
                 q=query,
                 labelIds=labels_ids,
-                includeSpamTrash=include_spam_trash
+                includeSpamTrash=include_spam_trash,
+                maxResults=page_size
             ).execute()
-
-            message_refs = []
-            if 'messages' in response:  # ensure request was successful
-                message_refs.extend(response['messages'])
-
-            while 'nextPageToken' in response:
-                page_token = response['nextPageToken']
-                response = self.service.users().messages().list(
-                    userId=user_id,
-                    q=query,
-                    labelIds=labels_ids,
-                    includeSpamTrash=include_spam_trash,
-                    pageToken=page_token
-                ).execute()
-
-                message_refs.extend(response['messages'])
-
-            return self._get_messages_from_refs(user_id, message_refs,
-                                                attachments)
 
         except HttpError as error:
             # Pass along the error
             raise error
+
+        return self._paginate_messages(user_id, labels_ids, query,
+                                       include_spam_trash, attachments,
+                                       page_size, response)
+
+    def _paginate_messages(
+        self,
+        user_id: str,
+        labels_ids: List[str],
+        query: str,
+        include_spam_trash: bool,
+        attachments: str,
+        page_size: int,
+        first_response: dict
+    ) -> Iterator[Message]:
+        """
+        Lazily yields the messages matching a search, one API page at a time.
+
+        Args:
+            user_id: The user's email address.
+            labels_ids: Label IDs messages must match.
+            query: A Gmail query to match.
+            include_spam_trash: Whether to include messages from spam or trash.
+            attachments: Accepted values are 'ignore', 'reference', and
+                'download'.
+            page_size: The number of message references fetched per API page.
+            first_response: The already-executed response for the first page.
+
+        Yields:
+            The Message objects, downloaded one page at a time.
+
+        Raises:
+            googleapiclient.errors.HttpError: There was an error executing the
+                HTTP request. An error permanently exhausts the iterator.
+
+        """
+
+        response = first_response
+        while True:
+            # The final page may contain a page token but no 'messages' key.
+            message_refs = response.get('messages', [])
+            yield from self._get_messages_from_refs(user_id, message_refs,
+                                                    attachments)
+
+            page_token = response.get('nextPageToken')
+            if not page_token:
+                return
+
+            # Go through the `service` property each page so the token is
+            # refreshed even if the consumer pauses between pages.
+            response = self.service.users().messages().list(
+                userId=user_id,
+                q=query,
+                labelIds=labels_ids,
+                includeSpamTrash=include_spam_trash,
+                maxResults=page_size,
+                pageToken=page_token
+            ).execute()
 
     def list_labels(self, user_id: str = 'me') -> List[Label]:
         """
@@ -661,7 +814,8 @@ class Gmail(object):
         parallel: bool = True
     ) -> List[Message]:
         """
-        Retrieves the actual messages from a list of references.
+        Retrieves the actual messages from a list of references. Called by
+        get_messages() once per page of message references.
 
         Args:
             user_id: The account the messages belong to.
@@ -700,20 +854,27 @@ class Gmail(object):
         )
         batch_size = math.ceil(len(message_refs) / num_threads)
         message_lists = [None] * num_threads
+        errors = [None] * num_threads
 
         def thread_download_batch(thread_num):
-            gmail = Gmail(_creds=self.creds)
+            # Capture exceptions so they propagate to the caller instead of
+            # dying with the thread and leaving a None slot in message_lists.
+            try:
+                gmail = Gmail(_creds=self.creds)
 
-            start = thread_num * batch_size
-            end = min(len(message_refs), (thread_num + 1) * batch_size)
-            message_lists[thread_num] = [
-                gmail._build_message_from_ref(
-                    user_id, message_refs[i], attachments
-                )
-                for i in range(start, end)
-            ]
+                start = thread_num * batch_size
+                end = min(len(message_refs), (thread_num + 1) * batch_size)
+                message_lists[thread_num] = [
+                    gmail._build_message_from_ref(
+                        user_id, message_refs[i], attachments
+                    )
+                    for i in range(start, end)
+                ]
 
-            gmail.service.close()
+                gmail.service.close()
+
+            except BaseException as error:
+                errors[thread_num] = error
 
         threads = [
             threading.Thread(target=thread_download_batch, args=(i,))
@@ -725,6 +886,10 @@ class Gmail(object):
 
         for t in threads:
             t.join()
+
+        for error in errors:
+            if error is not None:
+                raise error
 
         return sum(message_lists, [])
 

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -943,8 +943,12 @@ class Gmail(object):
             payload = message['payload']
             headers = payload['headers']
 
+            internal_date = None
+            if 'internalDate' in message:
+                internal_date = int(message['internalDate'])
+
             # Get header fields (date, from, to, subject)
-            date = ''
+            header_date = ''
             sender = ''
             recipient = ''
             subject = ''
@@ -954,9 +958,11 @@ class Gmail(object):
             for hdr in headers:
                 if hdr['name'].lower() == 'date':
                     try:
-                        date = str(parser.parse(hdr['value']).astimezone())
+                        header_date = str(
+                            parser.parse(hdr['value']).astimezone()
+                        )
                     except Exception:
-                        date = hdr['value']
+                        header_date = hdr['value']
                 elif hdr['name'].lower() == 'from':
                     sender = hdr['value']
                 elif hdr['name'].lower() == 'to':
@@ -1003,7 +1009,8 @@ class Gmail(object):
                 recipient,
                 sender,
                 subject,
-                date,
+                header_date,
+                internal_date,
                 snippet,
                 plain_msg,
                 html_msg,

--- a/simplegmail/message.py
+++ b/simplegmail/message.py
@@ -30,7 +30,9 @@ class Message(object):
         recipient: who the message was addressed to.
         sender: who the message was sent from.
         subject: the subject line of the message.
-        date: the date the message was sent.
+        headerDate: the date the message was sent, from the Date header.
+        internalDate: Gmail's internal received timestamp, in milliseconds
+            since the epoch. None if not provided by the API.
         snippet: the snippet line for the message.
         plain: the plaintext contents of the message. Default None.
         html: the HTML contents of the message. Default None.
@@ -47,7 +49,9 @@ class Message(object):
         recipient (str): who the message was addressed to.
         sender (str): who the message was sent from.
         subject (str): the subject line of the message.
-        date (str): the date the message was sent.
+        headerDate (str): the date the message was sent, from the Date header.
+        internalDate (Optional[int]): Gmail's internal received timestamp, in
+            milliseconds since the epoch.
         snippet (str): the snippet line for the message.
         plain (str): the plaintext contents of the message.
         html (str): the HTML contents of the message.
@@ -69,7 +73,8 @@ class Message(object):
         recipient: str,
         sender: str,
         subject: str,
-        date: str,
+        headerDate: str,
+        internalDate: Optional[int],
         snippet,
         plain: Optional[str] = None,
         html: Optional[str] = None,
@@ -87,7 +92,8 @@ class Message(object):
         self.recipient = recipient
         self.sender = sender
         self.subject = subject
-        self.date = date
+        self.headerDate = headerDate
+        self.internalDate = internalDate
         self.snippet = snippet
         self.plain = plain
         self.html = html

--- a/tests/test_get_messages.py
+++ b/tests/test_get_messages.py
@@ -1,0 +1,597 @@
+"""
+File: test_get_messages.py
+--------------------------
+Tests for the lazy iterator behavior of Gmail.get_messages(). Uses stubbed
+service objects; no HTTP requests are made.
+
+"""
+
+from collections.abc import Iterator
+
+import httplib2
+import pytest
+from googleapiclient.errors import HttpError
+
+import simplegmail.gmail
+from simplegmail.gmail import Gmail
+from simplegmail.label import Label
+
+
+class FakeRequest(object):
+    def __init__(self, response):
+        self._response = response
+
+    def execute(self):
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+class FakeService(object):
+    """Stands in for the Gmail API service object; records list() calls."""
+
+    def __init__(self, pages):
+        self.pages = pages  # responses (or exceptions) returned in order
+        self.list_calls = []
+
+    def users(self):
+        return self
+
+    def messages(self):
+        return self
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        return FakeRequest(self.pages[len(self.list_calls) - 1])
+
+
+class FakeCreds(object):
+    def __init__(self):
+        self.access_token_expired = False
+        self.refresh_calls = 0
+
+    def refresh(self, http):
+        self.refresh_calls += 1
+        self.access_token_expired = False
+
+
+class FakeWorkerService(object):
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def http_error(status='403'):
+    return HttpError(httplib2.Response({'status': status}), b'error')
+
+
+def make_gmail(pages, stub_refs=True):
+    gmail = Gmail.__new__(Gmail)  # skip auth in __init__
+    gmail.creds = FakeCreds()
+    gmail._service = FakeService(pages)
+    gmail.refs_calls = []
+
+    if stub_refs:
+        # Bypass the parallel download machinery: pass message refs through
+        # as-is, recording the (user_id, attachments) pair for each page.
+        def fake_get_messages_from_refs(user_id, message_refs,
+                                        attachments='reference'):
+            gmail.refs_calls.append((user_id, attachments))
+            return message_refs
+
+        gmail._get_messages_from_refs = fake_get_messages_from_refs
+
+    return gmail
+
+
+def stub_worker_gmail(monkeypatch, builder):
+    """
+    Replaces the per-thread Gmail construction inside the real
+    _get_messages_from_refs with a lightweight fake whose
+    _build_message_from_ref calls `builder(ref)`.
+    """
+
+    workers = []
+
+    class FakeWorkerGmail(object):
+        def __init__(self, _creds=None):
+            self.service = FakeWorkerService()
+            workers.append(self)
+
+        def _build_message_from_ref(self, user_id, ref, attachments):
+            return builder(ref)
+
+    monkeypatch.setattr(simplegmail.gmail, 'Gmail', FakeWorkerGmail)
+    return workers
+
+
+class TestGetMessages(object):
+
+    def test_returns_lazy_iterator(self):
+        gmail = make_gmail([{'messages': [{'id': '1'}]}])
+        result = gmail.get_messages()
+        assert isinstance(result, Iterator)
+        assert not isinstance(result, list)
+
+    def test_single_page(self):
+        gmail = make_gmail([{'messages': [{'id': '1'}, {'id': '2'}]}])
+        assert list(gmail.get_messages()) == [{'id': '1'}, {'id': '2'}]
+        assert len(gmail._service.list_calls) == 1
+
+    def test_pages_are_fetched_lazily(self):
+        pages = [
+            {'messages': [{'id': '1'}, {'id': '2'}], 'nextPageToken': 'tok'},
+            {'messages': [{'id': '3'}]},
+        ]
+        gmail = make_gmail(pages)
+        it = gmail.get_messages(page_size=2)
+
+        # Only the first page is fetched at call time.
+        assert len(gmail._service.list_calls) == 1
+
+        assert next(it) == {'id': '1'}
+        assert next(it) == {'id': '2'}
+        assert len(gmail._service.list_calls) == 1  # page 2 not fetched yet
+
+        assert next(it) == {'id': '3'}
+        assert len(gmail._service.list_calls) == 2
+        assert gmail._service.list_calls[1]['pageToken'] == 'tok'
+        assert gmail._service.list_calls[1]['maxResults'] == 2
+
+        with pytest.raises(StopIteration):
+            next(it)
+
+    def test_page_size_passed_as_max_results(self):
+        gmail = make_gmail([{}])
+        list(gmail.get_messages(page_size=42))
+        call = gmail._service.list_calls[0]
+        assert call['maxResults'] == 42
+        assert 'pageToken' not in call
+
+    def test_empty_mailbox(self):
+        gmail = make_gmail([{}])
+        assert list(gmail.get_messages()) == []
+
+    def test_final_page_with_token_but_no_messages(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 'tok'},
+            {},
+        ]
+        gmail = make_gmail(pages)
+        assert list(gmail.get_messages()) == [{'id': '1'}]
+        assert len(gmail._service.list_calls) == 2
+
+    def test_empty_intermediate_page_is_skipped(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 't1'},
+            {'nextPageToken': 't2'},  # empty middle page, still has a token
+            {'messages': [{'id': '2'}]},
+        ]
+        gmail = make_gmail(pages)
+        it = gmail.get_messages()
+
+        assert next(it) == {'id': '1'}
+        assert next(it) == {'id': '2'}  # one next() drives two list() calls
+        assert [c.get('pageToken') for c in gmail._service.list_calls] == \
+            [None, 't1', 't2']
+        with pytest.raises(StopIteration):
+            next(it)
+
+    def test_empty_string_next_page_token_terminates(self):
+        # Termination is a truthiness check, not a key-presence check.
+        gmail = make_gmail([{'messages': [{'id': '1'}], 'nextPageToken': ''}])
+        assert list(gmail.get_messages()) == [{'id': '1'}]
+        assert len(gmail._service.list_calls) == 1
+
+
+class TestValidation(object):
+
+    def test_invalid_attachments_raises_before_any_request(self):
+        gmail = make_gmail([])
+        with pytest.raises(ValueError):
+            gmail.get_messages(attachments='referance')
+        assert gmail._service.list_calls == []
+
+    def test_all_valid_attachments_options_accepted(self):
+        for attachments in ('ignore', 'reference', 'download'):
+            gmail = make_gmail([{}])
+            list(gmail.get_messages(attachments=attachments))
+            assert len(gmail._service.list_calls) == 1
+
+    def test_invalid_page_size_raises_before_any_request(self):
+        gmail = make_gmail([])
+        for page_size in (0, -1, 501):
+            with pytest.raises(ValueError):
+                gmail.get_messages(page_size=page_size)
+        assert gmail._service.list_calls == []
+
+    def test_page_size_boundaries_accepted(self):
+        for page_size in (1, 500):
+            gmail = make_gmail([{}])
+            list(gmail.get_messages(page_size=page_size))
+            assert gmail._service.list_calls[0]['maxResults'] == page_size
+
+
+class TestErrorTiming(object):
+
+    def test_first_page_error_raises_at_call_time(self):
+        gmail = make_gmail([http_error()])
+        with pytest.raises(HttpError):
+            gmail.get_messages()
+
+    def test_later_page_error_raises_during_iteration(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 'tok'},
+            http_error(),
+        ]
+        gmail = make_gmail(pages)
+        it = gmail.get_messages()
+
+        assert next(it) == {'id': '1'}
+        with pytest.raises(HttpError):
+            next(it)
+
+    def test_download_error_raises_during_iteration(self):
+        gmail = make_gmail([{'messages': [{'id': '1'}]}])
+
+        def failing_get_messages_from_refs(user_id, message_refs,
+                                           attachments='reference'):
+            raise http_error()
+
+        gmail._get_messages_from_refs = failing_get_messages_from_refs
+
+        it = gmail.get_messages()  # listing succeeds; no error at call time
+        with pytest.raises(HttpError):
+            next(it)
+
+    def test_error_permanently_exhausts_iterator(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 'tok'},
+            http_error(),
+            {'messages': [{'id': '2'}]},  # must never be fetched
+        ]
+        gmail = make_gmail(pages)
+        it = gmail.get_messages()
+
+        assert next(it) == {'id': '1'}
+        with pytest.raises(HttpError):
+            next(it)
+
+        # A failed iterator cannot be resumed; it is exhausted, not retried.
+        with pytest.raises(StopIteration):
+            next(it)
+        assert len(gmail._service.list_calls) == 2
+
+
+class TestIteratorContract(object):
+
+    def test_iterator_is_single_pass(self):
+        gmail = make_gmail([{'messages': [{'id': '1'}]}])
+        it = gmail.get_messages()
+        assert list(it) == [{'id': '1'}]
+        assert list(it) == []  # second pass yields nothing
+
+    def test_result_is_always_truthy_even_when_empty(self):
+        # Documents the migration footgun: `if not messages:` is dead code.
+        gmail = make_gmail([{}])
+        messages = gmail.get_messages()
+        assert bool(messages)
+        assert list(messages) == []
+
+    def test_result_does_not_support_indexing_or_len(self):
+        gmail = make_gmail([{'messages': [{'id': '1'}]}])
+        messages = gmail.get_messages()
+        with pytest.raises(TypeError):
+            messages[0]
+        with pytest.raises(TypeError):
+            len(messages)
+
+    def test_next_with_default_on_no_match(self):
+        gmail = make_gmail([{}])
+        assert next(gmail.get_messages(query='no match'), None) is None
+        assert len(gmail._service.list_calls) == 1
+
+    def test_abandoning_iterator_stops_fetching(self):
+        pages = [
+            {'messages': [{'id': '1'}, {'id': '2'}], 'nextPageToken': 'tok'},
+            {'messages': [{'id': '3'}]},
+        ]
+        gmail = make_gmail(pages)
+        it = gmail.get_messages()
+        next(it)
+        it.close()  # explicit abandonment (same as `break` + GC)
+
+        assert len(gmail._service.list_calls) == 1  # page 2 never fetched
+        with pytest.raises(StopIteration):
+            next(it)
+
+    def test_two_iterators_from_same_gmail_are_independent(self):
+        pages = [
+            {'messages': [{'id': 'a1'}], 'nextPageToken': 'ta'},
+            {'messages': [{'id': 'b1'}], 'nextPageToken': 'tb'},
+            {'messages': [{'id': 'a2'}]},
+            {'messages': [{'id': 'b2'}]},
+        ]
+        gmail = make_gmail(pages)
+        it1 = gmail.get_messages()  # eagerly fetches pages[0]
+        it2 = gmail.get_messages()  # eagerly fetches pages[1]
+
+        assert next(it1) == {'id': 'a1'}
+        assert next(it2) == {'id': 'b1'}
+        assert next(it1) == {'id': 'a2'}  # follows 'ta', not it2's token
+        assert next(it2) == {'id': 'b2'}  # follows 'tb'
+
+        calls = gmail._service.list_calls
+        assert calls[2]['pageToken'] == 'ta'
+        assert calls[3]['pageToken'] == 'tb'
+
+
+class TestRequestParameters(object):
+
+    def test_all_parameters_repeated_on_every_page(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 't1'},
+            {'messages': [{'id': '2'}], 'nextPageToken': 't2'},
+            {'messages': [{'id': '3'}]},
+        ]
+        gmail = make_gmail(pages)
+        list(gmail.get_messages(user_id='someone@else.com', query='is:unread',
+                                include_spam_trash=True, page_size=50))
+
+        calls = gmail._service.list_calls
+        assert len(calls) == 3
+        assert [c.get('pageToken') for c in calls] == [None, 't1', 't2']
+        for call in calls:
+            assert call['userId'] == 'someone@else.com'
+            assert call['q'] == 'is:unread'
+            assert call['includeSpamTrash'] is True
+            assert call['maxResults'] == 50
+
+    def test_attachments_option_forwarded_every_page(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 'tok'},
+            {'messages': [{'id': '2'}]},
+        ]
+        gmail = make_gmail(pages)
+        list(gmail.get_messages(attachments='download'))
+        assert gmail.refs_calls == [('me', 'download'), ('me', 'download')]
+
+    def test_label_objects_and_strings_normalized(self):
+        gmail = make_gmail([{}])
+        list(gmail.get_messages(labels=[Label('Custom', 'Label_7'),
+                                        'Label_raw']))
+        assert gmail._service.list_calls[0]['labelIds'] == ['Label_7',
+                                                            'Label_raw']
+
+    def test_user_id_forwarded_to_hydration_every_page(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 'tok'},
+            {'messages': [{'id': '2'}]},
+        ]
+        gmail = make_gmail(pages)
+        list(gmail.get_messages(user_id='someone@else.com'))
+        assert gmail.refs_calls == [('someone@else.com', 'reference')] * 2
+
+    def test_token_refreshed_between_pages(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 'tok'},
+            {'messages': [{'id': '2'}]},
+        ]
+        gmail = make_gmail(pages)
+        it = gmail.get_messages()
+        assert next(it) == {'id': '1'}
+
+        # Token expires while the consumer is paused between pages; the
+        # generator must re-enter the `service` property, which refreshes.
+        gmail.creds.access_token_expired = True
+        assert next(it) == {'id': '2'}
+        assert gmail.creds.refresh_calls == 1
+
+
+class TestWrappers(object):
+
+    @pytest.mark.parametrize('method,label_id', [
+        ('get_starred_messages', 'STARRED'),
+        ('get_important_messages', 'IMPORTANT'),
+        ('get_unread_messages', 'UNREAD'),
+        ('get_drafts', 'DRAFT'),
+        ('get_sent_messages', 'SENT'),
+    ])
+    def test_wrapper_adds_label_and_forwards_page_size(self, method,
+                                                       label_id):
+        gmail = make_gmail([{}])
+        result = getattr(gmail, method)(page_size=9)
+        assert isinstance(result, Iterator)
+        assert list(result) == []
+
+        call = gmail._service.list_calls[0]
+        assert call['labelIds'] == [label_id]
+        assert call['maxResults'] == 9
+        assert call['includeSpamTrash'] is False
+
+    @pytest.mark.parametrize('method,label_id', [
+        ('get_trash_messages', 'TRASH'),
+        ('get_spam_messages', 'SPAM'),
+    ])
+    def test_spam_trash_wrappers_forward_correctly(self, method, label_id):
+        gmail = make_gmail([{}])
+        list(getattr(gmail, method)(page_size=9))
+
+        call = gmail._service.list_calls[0]
+        assert call['labelIds'] == [label_id]
+        # The positional True must land in include_spam_trash, not page_size.
+        assert call['includeSpamTrash'] is True
+        assert call['maxResults'] == 9
+
+    def test_get_unread_inbox_forwards_arguments(self):
+        gmail = make_gmail([{'messages': [{'id': '1'}]}])
+        result = gmail.get_unread_inbox(attachments='ignore', page_size=7)
+
+        assert isinstance(result, Iterator)
+        assert list(result) == [{'id': '1'}]
+
+        call = gmail._service.list_calls[0]
+        assert call['labelIds'] == ['INBOX', 'UNREAD']
+        assert call['maxResults'] == 7
+        assert gmail.refs_calls == [('me', 'ignore')]
+
+    @pytest.mark.parametrize('method', [
+        'get_starred_messages', 'get_important_messages',
+        'get_unread_messages', 'get_drafts', 'get_sent_messages',
+    ])
+    def test_wrapper_forwards_user_id_query_and_spam_trash(self, method):
+        gmail = make_gmail([{}])
+        list(getattr(gmail, method)(user_id='someone@else.com',
+                                    query='has:attachment',
+                                    include_spam_trash=True))
+        call = gmail._service.list_calls[0]
+        assert call['userId'] == 'someone@else.com'
+        assert call['q'] == 'has:attachment'
+        assert call['includeSpamTrash'] is True
+
+    def test_get_unread_inbox_forwards_user_id_and_query(self):
+        gmail = make_gmail([{}])
+        list(gmail.get_unread_inbox(user_id='someone@else.com',
+                                    query='has:attachment'))
+        call = gmail._service.list_calls[0]
+        assert call['userId'] == 'someone@else.com'
+        assert call['q'] == 'has:attachment'
+
+    def test_wrapper_combines_user_labels_with_its_own(self):
+        gmail = make_gmail([{}])
+        list(gmail.get_starred_messages(labels=['MyLabel']))
+        assert gmail._service.list_calls[0]['labelIds'] == ['MyLabel',
+                                                            'STARRED']
+
+    def test_wrappers_are_lazy(self):
+        pages = [
+            {'messages': [{'id': '1'}], 'nextPageToken': 'tok'},
+            {'messages': [{'id': '2'}]},
+        ]
+        gmail = make_gmail(pages)
+        gmail.get_starred_messages()
+        assert len(gmail._service.list_calls) == 1  # first page only
+
+    def test_wrapper_validation_is_eager(self):
+        gmail = make_gmail([])
+        with pytest.raises(ValueError):
+            gmail.get_starred_messages(attachments='bogus')
+        assert gmail._service.list_calls == []
+
+
+class TestGetMessagesFromRefs(object):
+    """Tests the real threaded download machinery, with only the per-thread
+    Gmail construction stubbed out."""
+
+    def test_order_preserved_across_threads(self, monkeypatch):
+        refs = [{'id': str(i)} for i in range(25)]
+        workers = stub_worker_gmail(monkeypatch, lambda ref: ref)
+        gmail = make_gmail([], stub_refs=False)
+
+        result = gmail._get_messages_from_refs('me', refs)
+
+        assert result == refs
+        assert len(workers) == 3  # ceil(25 refs / 10 per thread)
+        assert all(w.service.closed for w in workers)
+
+    def test_worker_http_error_propagates(self, monkeypatch):
+        # Without the error capture, a worker exception kills its thread and
+        # the caller crashes with TypeError from sum() over a None slot.
+        refs = [{'id': str(i)} for i in range(25)]
+
+        def builder(ref):
+            if ref['id'] == '7':
+                raise http_error()
+            return ref
+
+        stub_worker_gmail(monkeypatch, builder)
+        gmail = make_gmail([], stub_refs=False)
+
+        with pytest.raises(HttpError):
+            gmail._get_messages_from_refs('me', refs)
+
+    def test_error_in_last_thread_propagates(self, monkeypatch):
+        refs = [{'id': str(i)} for i in range(25)]
+
+        def builder(ref):
+            if ref['id'] == '24':  # last ref, handled by the last thread
+                raise http_error()
+            return ref
+
+        stub_worker_gmail(monkeypatch, builder)
+        gmail = make_gmail([], stub_refs=False)
+
+        with pytest.raises(HttpError):
+            gmail._get_messages_from_refs('me', refs)
+
+    def test_worker_failure_does_not_abort_other_threads(self, monkeypatch):
+        refs = [{'id': str(i)} for i in range(25)]
+        attempted = []  # list.append is thread-safe under the GIL
+
+        def builder(ref):
+            attempted.append(ref['id'])
+            if ref['id'] == '7':  # fails in the first thread's batch (0-8)
+                raise http_error()
+            return ref
+
+        workers = stub_worker_gmail(monkeypatch, builder)
+        gmail = make_gmail([], stub_refs=False)
+
+        with pytest.raises(HttpError):
+            gmail._get_messages_from_refs('me', refs)
+
+        # All threads are joined before the error is raised: the other two
+        # batches (refs 9-24) run to completion and close their services.
+        assert set(str(i) for i in range(9, 25)) <= set(attempted)
+        assert len(workers) == 3
+        assert sum(w.service.closed for w in workers) == 2
+
+    def test_base_exception_in_worker_propagates(self, monkeypatch):
+        class FakeInterrupt(BaseException):
+            pass
+
+        def builder(ref):
+            raise FakeInterrupt()
+
+        stub_worker_gmail(monkeypatch, builder)
+        gmail = make_gmail([], stub_refs=False)
+
+        with pytest.raises(FakeInterrupt):
+            gmail._get_messages_from_refs('me', [{'id': '0'}])
+
+    def test_empty_refs_spawn_no_threads(self, monkeypatch):
+        workers = stub_worker_gmail(monkeypatch, lambda ref: ref)
+        gmail = make_gmail([], stub_refs=False)
+
+        assert gmail._get_messages_from_refs('me', []) == []
+        assert workers == []
+
+    def test_sequential_path(self, monkeypatch):
+        refs = [{'id': '0'}, {'id': '1'}]
+        workers = stub_worker_gmail(monkeypatch, lambda ref: ref)
+        gmail = make_gmail([], stub_refs=False)
+        gmail._build_message_from_ref = (
+            lambda user_id, ref, attachments: ref
+        )
+
+        result = gmail._get_messages_from_refs('me', refs, parallel=False)
+
+        assert result == refs
+        assert workers == []  # no per-thread Gmail instances
+
+    def test_end_to_end_pagination_with_real_thread_machinery(self,
+                                                              monkeypatch):
+        pages = [
+            {'messages': [{'id': str(i)} for i in range(15)],
+             'nextPageToken': 'tok'},
+            {'messages': [{'id': '15'}]},
+        ]
+        stub_worker_gmail(monkeypatch, lambda ref: ref)
+        gmail = make_gmail(pages, stub_refs=False)
+
+        result = list(gmail.get_messages(page_size=15))
+
+        assert result == pages[0]['messages'] + pages[1]['messages']
+        assert len(gmail._service.list_calls) == 2

--- a/tests/test_message_dates.py
+++ b/tests/test_message_dates.py
@@ -1,0 +1,126 @@
+"""
+File: test_message_dates.py
+---------------------------
+Tests for the two date fields on Message: `headerDate` (parsed from the
+RFC 2822 Date header) and `internalDate` (Gmail's internal received
+timestamp, in epoch milliseconds). Uses stubbed service objects; no HTTP
+requests are made.
+
+"""
+
+import dateutil.parser as parser
+
+from simplegmail.gmail import Gmail
+
+
+class FakeRequest(object):
+    def __init__(self, response):
+        self._response = response
+
+    def execute(self):
+        return self._response
+
+
+class FakeService(object):
+    """Stands in for the Gmail API service; serves a single message JSON."""
+
+    def __init__(self, message_json):
+        self._message_json = message_json
+
+    def users(self):
+        return self
+
+    def messages(self):
+        return self
+
+    def get(self, userId, id):
+        return FakeRequest(self._message_json)
+
+
+class FakeCreds(object):
+    access_token_expired = False
+
+
+DATE_HEADER = 'Tue, 01 Jul 2025 12:30:00 +0000'
+INTERNAL_DATE_MS = 1751370600123  # arbitrary epoch-ms value
+
+
+def message_json(**overrides):
+    base = {
+        'id': 'msg1',
+        'threadId': 'thread1',
+        'snippet': 'hello there',
+        'internalDate': str(INTERNAL_DATE_MS),  # the API returns a string
+        'payload': {
+            'mimeType': 'multipart/mixed',
+            'body': {},
+            'headers': [
+                {'name': 'From', 'value': 'sender@example.com'},
+                {'name': 'To', 'value': 'recipient@example.com'},
+                {'name': 'Subject', 'value': 'Hi'},
+                {'name': 'Date', 'value': DATE_HEADER},
+            ],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def build_message(msg_json):
+    gmail = Gmail.__new__(Gmail)  # skip auth in __init__
+    gmail.creds = FakeCreds()
+    gmail._service = FakeService(msg_json)
+    return gmail._build_message_from_ref('me', {'id': 'msg1'})
+
+
+def payload_without_date_header():
+    payload = message_json()['payload']
+    payload['headers'] = [
+        h for h in payload['headers'] if h['name'] != 'Date'
+    ]
+    return payload
+
+
+class TestHeaderDate(object):
+
+    def test_parsed_from_date_header(self):
+        msg = build_message(message_json())
+        expected = str(parser.parse(DATE_HEADER).astimezone())
+        assert msg.headerDate == expected
+
+    def test_unparseable_header_kept_verbatim(self):
+        json = message_json()
+        json['payload']['headers'] = [
+            {'name': 'Date', 'value': 'not a real date'},
+        ]
+        msg = build_message(json)
+        assert msg.headerDate == 'not a real date'
+
+    def test_missing_date_header_is_empty_string(self):
+        msg = build_message(message_json(payload=payload_without_date_header()))
+        assert msg.headerDate == ''
+
+    def test_old_date_attribute_is_gone(self):
+        # `date` was renamed to `headerDate`; it must not linger as an alias
+        # that could silently diverge.
+        msg = build_message(message_json())
+        assert not hasattr(msg, 'date')
+
+
+class TestInternalDate(object):
+
+    def test_exposed_as_epoch_milliseconds_int(self):
+        msg = build_message(message_json())
+        assert msg.internalDate == INTERNAL_DATE_MS
+        assert isinstance(msg.internalDate, int)
+
+    def test_missing_internal_date_is_none(self):
+        json = message_json()
+        del json['internalDate']
+        msg = build_message(json)
+        assert msg.internalDate is None
+
+    def test_independent_of_date_header(self):
+        # internalDate comes from Gmail's own metadata, not from headers.
+        msg = build_message(message_json(payload=payload_without_date_header()))
+        assert msg.internalDate == INTERNAL_DATE_MS


### PR DESCRIPTION
Header date can be missing from email headers, therefore to have a complete email we need header date