### PR TITLE
[bug] Fix archive when Gmail omits label IDs

### DIFF
--- a/simplegmail/message.py
+++ b/simplegmail/message.py
@@ -387,6 +387,7 @@ class Message(object):
             raise error
 
         else:
+            res.setdefault('labelIds', [])
             assert all([lbl in res['labelIds'] for lbl in to_add]) \
                 and all([lbl not in res['labelIds'] for lbl in to_remove]), \
                 'An error occurred while modifying message label.'

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from simplegmail import label
+from simplegmail.message import Message
+
+
+def build_message(response):
+    service = MagicMock()
+    modify = service.users.return_value.messages.return_value.modify
+    modify.return_value.execute.return_value = response
+
+    message = Message(
+        service=service,
+        creds=MagicMock(),
+        user_id='me',
+        msg_id='message-id',
+        thread_id='thread-id',
+        recipient='recipient@example.com',
+        sender='sender@example.com',
+        subject='subject',
+        date='date',
+        snippet='snippet',
+        label_ids=[label.INBOX],
+    )
+    return message, modify
+
+
+def test_archive_handles_response_without_label_ids():
+    message, modify = build_message({})
+
+    message.archive()
+
+    assert message.label_ids == []
+    modify.assert_called_once_with(
+        userId='me',
+        id='message-id',
+        body={'addLabelIds': [], 'removeLabelIds': ['INBOX']},
+    )
+
+
+def test_modify_labels_uses_returned_label_ids():
+    message, _ = build_message({'labelIds': ['STARRED']})
+
+    message.modify_labels(label.STARRED, label.INBOX)
+
+    assert message.label_ids == ['STARRED']
+
+
+def test_missing_label_ids_does_not_hide_failed_addition():
+    message, _ = build_message({})
+
+    with pytest.raises(
+        AssertionError,
+        match='An error occurred while modifying message label.',
+    ):
+        message.star()
+
+    assert message.label_ids == [label.INBOX]


### PR DESCRIPTION
Treat a missing labelIds field in message modification responses as an empty list.

Fixes issue #51.