### PR TITLE
[bug] Propagate parallel message retrieval errors

### DIFF
--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -7,6 +7,7 @@ attachments) and retrieving mail with the full suite of Gmail search options.
 """
 
 import base64
+from concurrent.futures import ThreadPoolExecutor
 from email.mime.audio       import MIMEAudio
 from email.mime.application import MIMEApplication
 from email.mime.base        import MIMEBase
@@ -18,7 +19,6 @@ import math
 import mimetypes
 import os
 import re
-import threading
 from typing import List, Optional
 
 from bs4 import BeautifulSoup
@@ -699,34 +699,23 @@ class Gmail(object):
             max_num_threads
         )
         batch_size = math.ceil(len(message_refs) / num_threads)
-        message_lists = [None] * num_threads
 
-        def thread_download_batch(thread_num):
+        def download_batch(thread_num):
             gmail = Gmail(_creds=self.creds)
+            try:
+                start = thread_num * batch_size
+                end = min(len(message_refs), (thread_num + 1) * batch_size)
+                return [
+                    gmail._build_message_from_ref(
+                        user_id, message_refs[i], attachments
+                    )
+                    for i in range(start, end)
+                ]
+            finally:
+                gmail.service.close()
 
-            start = thread_num * batch_size
-            end = min(len(message_refs), (thread_num + 1) * batch_size)
-            message_lists[thread_num] = [
-                gmail._build_message_from_ref(
-                    user_id, message_refs[i], attachments
-                )
-                for i in range(start, end)
-            ]
-
-            gmail.service.close()
-
-        threads = [
-            threading.Thread(target=thread_download_batch, args=(i,))
-            for i in range(num_threads)
-        ]
-
-        for t in threads:
-            t.start()
-
-        for t in threads:
-            t.join()
-
-        return sum(message_lists, [])
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            return sum(executor.map(download_batch, range(num_threads)), [])
 
     def _build_message_from_ref(
         self,

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from simplegmail.gmail import Gmail
+
+
+def build_gmail():
+    gmail = Gmail.__new__(Gmail)
+    gmail.creds = MagicMock()
+    return gmail
+
+
+def build_worker(workers, build_message):
+    worker = MagicMock()
+    worker._build_message_from_ref.side_effect = build_message
+    workers.append(worker)
+    return worker
+
+
+def test_parallel_retrieval_preserves_order_and_closes_services():
+    gmail = build_gmail()
+    message_refs = [{'id': str(i)} for i in range(21)]
+    workers = []
+
+    def build_message(user_id, message_ref, attachments):
+        return message_ref['id']
+
+    with patch(
+        'simplegmail.gmail.Gmail',
+        side_effect=lambda **_: build_worker(workers, build_message),
+    ) as gmail_class:
+        messages = Gmail._get_messages_from_refs(
+            gmail, 'me', message_refs, attachments='ignore'
+        )
+
+    assert messages == [ref['id'] for ref in message_refs]
+    assert gmail_class.call_count == 3
+    assert all(worker.service.close.call_count == 1 for worker in workers)
+
+
+def test_parallel_retrieval_propagates_worker_errors_and_closes_services():
+    gmail = build_gmail()
+    message_refs = [{'id': str(i)} for i in range(11)]
+    workers = []
+    error = RuntimeError('download failed')
+
+    def build_message(user_id, message_ref, attachments):
+        if message_ref['id'] == '6':
+            raise error
+        return message_ref['id']
+
+    with patch(
+        'simplegmail.gmail.Gmail',
+        side_effect=lambda **_: build_worker(workers, build_message),
+    ):
+        with pytest.raises(RuntimeError) as raised:
+            Gmail._get_messages_from_refs(gmail, 'me', message_refs)
+
+    assert raised.value is error
+    assert len(workers) == 2
+    assert all(worker.service.close.call_count == 1 for worker in workers)


### PR DESCRIPTION
- replace manual retrieval threads with `ThreadPoolExecutor`
- propagate the original worker exception to the caller
- ensure every started worker service is closed

Fixes #73.