### PR TITLE
[breaking] Migrate authentication to google-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@ Gmail and enable.
 
 3. Click on the Credentials tab, then "Create Credentials" > "OAuth client ID".
 
-4. Select what kind of application this is for, and give it a memorable name.
-Fill out all necessary information for the credential (e.g., if choosing 
-"Web Application" make sure to add an Authorized Redirect URI. See 
-https://developers.google.com/identity/protocols/oauth2 for more infomation).
+4. Select "Desktop app" as the application type and give it a memorable name.
 
 5. Back on the credentials screen, click the download icon next to the 
 credential you just created to download it as a JSON object.
@@ -62,11 +59,15 @@ file if you choose to name it otherwise.)
 
 The first time you create a new instance of the `Gmail` class, a browser window 
 will open, and you'll be asked to give permissions to the application. This 
-will save an access token in a file named "gmail-token.json", and only needs to 
+will save an access token in a file named "gmail_token.json", and only needs to
 occur once.
 
-Additionally, you will need to ensure IMAP is enabled in your Gmail account
-settings.
+Existing `oauth2client` token files containing a refresh token are reused and
+rewritten in the current `google-auth` format after they are refreshed.
+
+To print the authorization URL without opening a browser, use
+`Gmail(noauth_local_webserver=True)`. Google no longer supports the old manual
+copy/paste flow, so authorization still redirects to a local callback server.
 
 You are now good to go!
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,10 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'google-api-python-client>=1.7.3',
+        'google-auth>=2.15.0',
+        'google-auth-oauthlib>=1.0.0',
         'beautifulsoup4>=4.12.1',
         'python-dateutil>=2.8.1',
-        'oauth2client>=4.1.3',
         'lxml>=4.4.2'
     ],
     extras_require={

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -23,11 +23,12 @@ from typing import List, Optional
 
 from bs4 import BeautifulSoup
 import dateutil.parser as parser
+from google.auth.credentials import Credentials as GoogleCredentials
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-from httplib2 import Http
-from oauth2client import client, file, tools
-from oauth2client.clientsecrets import InvalidClientSecretsError
 
 from simplegmail import label
 from simplegmail.attachment import Attachment
@@ -45,6 +46,8 @@ class Gmail(object):
             call).
         access_type: Whether to request a refresh token for usage without a
             user necessarily present. Either 'online' or 'offline'.
+        noauth_local_webserver: Whether to suppress opening the authorization
+            URL in a browser. The local callback server is always required.
 
     Attributes:
         client_secret_file (str): The name of the user's client secret file.
@@ -68,56 +71,85 @@ class Gmail(object):
         creds_file: str = 'gmail_token.json',
         access_type: str = 'offline',
         noauth_local_webserver: bool = False,
-        _creds: Optional[client.OAuth2Credentials] = None,
+        _creds: Optional[GoogleCredentials] = None,
     ) -> None:
         self.client_secret_file = client_secret_file
         self.creds_file = creds_file
 
-        try:
-            # The file gmail_token.json stores the user's access and refresh
-            # tokens, and is created automatically when the authorization flow
-            # completes for the first time.
-            if _creds:
-                self.creds = _creds
-            else:
-                store = file.Storage(self.creds_file)
-                self.creds = store.get()
+        if _creds is None:
+            self.creds = self._get_credentials(
+                access_type, noauth_local_webserver
+            )
+        else:
+            self.creds = _creds
 
-            if not self.creds or self.creds.invalid:
-                flow = client.flow_from_clientsecrets(
-                    self.client_secret_file, self._SCOPES
+        self._service = build(
+            'gmail', 'v1', credentials=self.creds, cache_discovery=False
+        )
+
+    def _get_credentials(
+        self,
+        access_type: str,
+        noauth_local_webserver: bool,
+    ) -> Credentials:
+        creds = None
+        if os.path.exists(self.creds_file):
+            try:
+                creds = Credentials.from_authorized_user_file(
+                    self.creds_file, self._SCOPES
+                )
+            except ValueError:
+                pass
+
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                try:
+                    flow = InstalledAppFlow.from_client_secrets_file(
+                        self.client_secret_file, self._SCOPES
+                    )
+                except FileNotFoundError as error:
+                    raise FileNotFoundError(
+                        f"Your client secret file '{self.client_secret_file}' "
+                        "is nonexistent. Follow the setup instructions at "
+                        "https://developers.google.com/gmail/api/quickstart/"
+                        "python."
+                    ) from error
+
+                creds = self._run_auth_flow(
+                    flow, access_type, noauth_local_webserver
                 )
 
-                flow.params['access_type'] = access_type
-                flow.params['prompt'] = 'consent'
+            with open(self.creds_file, 'w') as token:
+                token.write(creds.to_json())
 
-                args = []
-                if noauth_local_webserver:
-                    args.append('--noauth_local_webserver')
+        return creds
 
-                flags = tools.argparser.parse_args(args)
-                self.creds = tools.run_flow(flow, store, flags)
-
-            self._service = build(
-                'gmail', 'v1', http=self.creds.authorize(Http()),
-                cache_discovery=False
-            )
-
-        except InvalidClientSecretsError:
-            raise FileNotFoundError(
-                "Your 'client_secret.json' file is nonexistent. Make sure "
-                "the file is in the root directory of your application. If "
-                "you don't have a client secrets file, go to https://"
-                "developers.google.com/gmail/api/quickstart/python, and "
-                "follow the instructions listed there."
-            )
+    @staticmethod
+    def _run_auth_flow(
+        flow: InstalledAppFlow,
+        access_type: str,
+        noauth_local_webserver: bool,
+    ) -> Credentials:
+        for port in (8080, 8090, 0):
+            try:
+                return flow.run_local_server(
+                    port=port,
+                    open_browser=not noauth_local_webserver,
+                    access_type=access_type,
+                    prompt='consent',
+                )
+            except OSError:
+                if port == 0:
+                    raise
 
     @property
     def service(self) -> 'googleapiclient.discovery.Resource':
         # Since the token is only used through calls to the service object,
         # this ensure that the token is always refreshed before use.
-        if self.creds.access_token_expired:
-            self.creds.refresh(Http())
+        if self.creds.expired:
+            self.creds.refresh(Request())
 
         return self._service
 

--- a/simplegmail/message.py
+++ b/simplegmail/message.py
@@ -7,7 +7,8 @@ This module contains the implementation of the Message object.
 
 from typing import List, Optional, Union
 
-from httplib2 import Http
+from google.auth.credentials import Credentials
+from google.auth.transport.requests import Request
 from googleapiclient.errors import HttpError
 
 from simplegmail import label
@@ -62,7 +63,7 @@ class Message(object):
     def __init__(
         self,
         service: 'googleapiclient.discovery.Resource',
-        creds: 'oauth2client.client.OAuth2Credentials',
+        creds: Credentials,
         user_id: str,
         msg_id: str,
         thread_id: str,
@@ -99,8 +100,8 @@ class Message(object):
 
     @property
     def service(self) -> 'googleapiclient.discovery.Resource':
-        if self.creds.access_token_expired:
-            self.creds.refresh(Http())
+        if self.creds.expired:
+            self.creds.refresh(Request())
 
         return self._service
 

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,5 +1,6 @@
 import base64
-from unittest.mock import MagicMock, patch
+import json
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -17,6 +18,212 @@ def build_worker(workers, build_message):
     worker._build_message_from_ref.side_effect = build_message
     workers.append(worker)
     return worker
+
+
+def build_credentials(valid=True, expired=False, refresh_token='refresh'):
+    creds = MagicMock()
+    creds.valid = valid
+    creds.expired = expired
+    creds.refresh_token = refresh_token
+    creds.to_json.return_value = '{"token": "saved"}'
+    return creds
+
+
+def test_uses_injected_credentials_without_loading_token_file():
+    creds = build_credentials()
+    service = MagicMock()
+
+    with patch('simplegmail.gmail.build', return_value=service) as build:
+        gmail = Gmail(_creds=creds)
+
+    assert gmail.creds is creds
+    assert gmail.service is service
+    build.assert_called_once_with(
+        'gmail', 'v1', credentials=creds, cache_discovery=False
+    )
+
+
+def test_loads_valid_stored_credentials(tmp_path):
+    token_file = tmp_path / 'token.json'
+    token_file.write_text('{}')
+    creds = build_credentials()
+
+    with patch(
+        'simplegmail.gmail.Credentials.from_authorized_user_file',
+        return_value=creds,
+    ) as load:
+        with patch(
+            'simplegmail.gmail.InstalledAppFlow.from_client_secrets_file'
+        ) as start_flow:
+            with patch('simplegmail.gmail.build'):
+                gmail = Gmail(creds_file=str(token_file))
+
+    assert gmail.creds is creds
+    load.assert_called_once_with(str(token_file), Gmail._SCOPES)
+    start_flow.assert_not_called()
+    assert token_file.read_text() == '{}'
+
+
+def test_refreshes_and_saves_expired_credentials(tmp_path):
+    token_file = tmp_path / 'token.json'
+    token_file.write_text('{}')
+    creds = build_credentials(valid=False, expired=True)
+    request = MagicMock()
+
+    with patch(
+        'simplegmail.gmail.Credentials.from_authorized_user_file',
+        return_value=creds,
+    ):
+        with patch('simplegmail.gmail.Request', return_value=request):
+            with patch('simplegmail.gmail.build'):
+                Gmail(creds_file=str(token_file))
+
+    creds.refresh.assert_called_once_with(request)
+    assert token_file.read_text() == creds.to_json.return_value
+
+
+@pytest.mark.parametrize(
+    ('noauth_local_webserver', 'open_browser'),
+    [(False, True), (True, False)],
+)
+def test_authorizes_and_saves_new_credentials(
+    tmp_path, noauth_local_webserver, open_browser
+):
+    token_file = tmp_path / f'token-{open_browser}.json'
+    secret_file = tmp_path / 'client-secret.json'
+    creds = build_credentials()
+    flow = MagicMock()
+    flow.run_local_server.return_value = creds
+
+    with patch(
+        'simplegmail.gmail.InstalledAppFlow.from_client_secrets_file',
+        return_value=flow,
+    ) as start_flow:
+        with patch('simplegmail.gmail.build'):
+            gmail = Gmail(
+                client_secret_file=str(secret_file),
+                creds_file=str(token_file),
+                access_type='online',
+                noauth_local_webserver=noauth_local_webserver,
+            )
+
+    assert gmail.creds is creds
+    start_flow.assert_called_once_with(str(secret_file), Gmail._SCOPES)
+    flow.run_local_server.assert_called_once_with(
+        port=8080,
+        open_browser=open_browser,
+        access_type='online',
+        prompt='consent',
+    )
+    assert token_file.read_text() == creds.to_json.return_value
+
+
+def test_reauthorizes_when_stored_credentials_are_invalid(tmp_path):
+    token_file = tmp_path / 'token.json'
+    token_file.write_text('invalid')
+    creds = build_credentials()
+    flow = MagicMock()
+    flow.run_local_server.return_value = creds
+
+    with patch(
+        'simplegmail.gmail.Credentials.from_authorized_user_file',
+        side_effect=ValueError,
+    ):
+        with patch(
+            'simplegmail.gmail.InstalledAppFlow.from_client_secrets_file',
+            return_value=flow,
+        ):
+            with patch('simplegmail.gmail.build'):
+                Gmail(creds_file=str(token_file))
+
+    assert token_file.read_text() == creds.to_json.return_value
+
+
+def test_authorization_uses_an_available_callback_port():
+    creds = build_credentials()
+    flow = MagicMock()
+    flow.run_local_server.side_effect = [OSError, OSError, creds]
+
+    result = Gmail._run_auth_flow(flow, 'offline', False)
+
+    assert result is creds
+    assert flow.run_local_server.call_args_list == [
+        call(
+            port=8080,
+            open_browser=True,
+            access_type='offline',
+            prompt='consent',
+        ),
+        call(
+            port=8090,
+            open_browser=True,
+            access_type='offline',
+            prompt='consent',
+        ),
+        call(
+            port=0,
+            open_browser=True,
+            access_type='offline',
+            prompt='consent',
+        ),
+    ]
+
+
+def test_reuses_legacy_oauth2client_token(tmp_path):
+    token_file = tmp_path / 'token.json'
+    token_file.write_text(json.dumps({
+        'access_token': 'legacy-access-token',
+        'client_id': 'client-id',
+        'client_secret': 'client-secret',
+        'refresh_token': 'refresh-token',
+        'token_expiry': '2020-01-01T00:00:00Z',
+        'token_uri': 'https://oauth2.googleapis.com/token',
+        '_class': 'OAuth2Credentials',
+        '_module': 'oauth2client.client',
+    }))
+
+    with patch(
+        'simplegmail.gmail.InstalledAppFlow.from_client_secrets_file'
+    ) as start_flow:
+        with patch(
+            'simplegmail.gmail.Credentials.refresh'
+        ) as refresh:
+            with patch('simplegmail.gmail.build'):
+                gmail = Gmail(creds_file=str(token_file))
+
+    assert gmail.creds.refresh_token == 'refresh-token'
+    refresh.assert_called_once()
+    start_flow.assert_not_called()
+    assert json.loads(token_file.read_text())['refresh_token'] == 'refresh-token'
+
+
+def test_missing_client_secret_has_clear_error(tmp_path):
+    secret_file = tmp_path / 'missing-client-secret.json'
+
+    with patch(
+        'simplegmail.gmail.InstalledAppFlow.from_client_secrets_file',
+        side_effect=FileNotFoundError,
+    ):
+        with pytest.raises(FileNotFoundError) as raised:
+            Gmail(
+                client_secret_file=str(secret_file),
+                creds_file=str(tmp_path / 'token.json'),
+            )
+
+    assert str(secret_file) in str(raised.value)
+
+
+def test_service_refreshes_expired_credentials():
+    gmail = Gmail.__new__(Gmail)
+    gmail.creds = build_credentials(expired=True)
+    gmail._service = MagicMock()
+    request = MagicMock()
+
+    with patch('simplegmail.gmail.Request', return_value=request):
+        service = gmail.service
+
+    assert service is gmail._service
+    gmail.creds.refresh.assert_called_once_with(request)
 
 
 def test_html_payload_handles_deeply_nested_content():

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -58,3 +58,15 @@ def test_missing_label_ids_does_not_hide_failed_addition():
         message.star()
 
     assert message.label_ids == [label.INBOX]
+
+
+def test_service_refreshes_expired_credentials():
+    message, _ = build_message({})
+    message.creds.expired = True
+    request = MagicMock()
+
+    with patch('simplegmail.message.Request', return_value=request):
+        service = message.service
+
+    assert service is message._service
+    message.creds.refresh.assert_called_once_with(request)


### PR DESCRIPTION
- replace deprecated `oauth2client` authentication with `google-auth`
- use Google’s supported local-server OAuth flow
- migrate existing `oauth2client` token files containing refresh tokens
- update authentication setup instructions and dependencies

Existing offline token files containing refresh tokens are reused and converted to the current format.

This migration changes the credential objects exposed through `Gmail.creds` and `Message.creds` from `oauth2client` credentials to `google-auth` credentials.

Because Google discontinued manual out-of-band authorization, `noauth_local_webserver=True` now suppresses automatic browser launch but still requires a local callback server. Legacy online tokens without refresh tokens may require authorization again.

Fixes #105.