### PR TITLE
[docs] Handle HTML-only messages in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ for message in messages:
     print("Date: " + message.date)
     print("Preview: " + message.snippet)
     
-    print("Message Body: " + message.plain)  # or message.html
+    print("Message Body:", message.plain or message.html or "")
 ```
 
 ### Marking messages:


### PR DESCRIPTION
- update the README example to handle messages without a plain-text body

Closes #110.