### PR TITLE
[feature] Add draft email creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ params = {
 message = gmail.send_message(**params)  # equivalent to send_message(to="you@youremail.com", sender=...)
 ```
 
+### Create a draft:
+
+```python
+from simplegmail import Gmail
+
+gmail = Gmail()
+
+draft = gmail.create_draft(
+  to="you@youremail.com",
+  sender="me@myemail.com",
+  subject="My first draft",
+  msg_plain="This message is not ready to send yet."
+)
+print(draft["id"])
+```
+
 It couldn't be easier!
 
 ### Retrieving messages:

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -208,6 +208,61 @@ class Gmail(object):
             # Pass along the error
             raise error
 
+    def create_draft(
+        self,
+        sender: str,
+        to: str,
+        subject: str = '',
+        msg_html: Optional[str] = None,
+        msg_plain: Optional[str] = None,
+        cc: Optional[List[str]] = None,
+        bcc: Optional[List[str]] = None,
+        attachments: Optional[List[str]] = None,
+        signature: bool = False,
+        user_id: str = 'me'
+    ) -> dict:
+        """Creates an email draft.
+
+        Args:
+            sender: The email address the message is being sent from.
+            to: The email address the message is being sent to.
+            subject: The subject line of the email.
+            msg_html: The HTML message of the email.
+            msg_plain: The plain text alternate message of the email.
+            cc: The list of email addresses to be cc'd.
+            bcc: The list of email addresses to be bcc'd.
+            attachments: The list of attachment file names.
+            signature: Whether the account signature should be added to the
+                message.
+            user_id: The address of the account creating the draft. 'me' for
+                the default address associated with the account.
+
+        Returns:
+            The draft resource returned by the Gmail API.
+
+        Raises:
+            googleapiclient.errors.HttpError: There was an error executing the
+                HTTP request.
+
+        """
+
+        message = self._create_message(
+            sender=sender,
+            to=to,
+            subject=subject,
+            msg_html=msg_html,
+            msg_plain=msg_plain,
+            cc=cc,
+            bcc=bcc,
+            attachments=attachments,
+            signature=signature,
+            user_id=user_id
+        )
+        return self.service.users().drafts().create(
+            userId=user_id,
+            body={'message': message}
+        ).execute()
+
     def get_unread_inbox(
         self,
         user_id: str = 'me',

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -226,6 +226,37 @@ def test_service_refreshes_expired_credentials():
     gmail.creds.refresh.assert_called_once_with(request)
 
 
+def test_create_draft_uses_message_builder_and_returns_api_resource():
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+    gmail._create_message = MagicMock(return_value={'raw': 'encoded-message'})
+    params = {
+        'sender': 'sender@example.com',
+        'to': 'recipient@example.com',
+        'subject': 'Subject',
+        'msg_html': '<p>HTML</p>',
+        'msg_plain': 'Plain',
+        'cc': ['cc@example.com'],
+        'bcc': ['bcc@example.com'],
+        'attachments': ['attachment.txt'],
+        'signature': True,
+        'user_id': 'account@example.com',
+    }
+    draft = {'id': 'draft-id', 'message': {'id': 'message-id'}}
+    drafts = gmail._service.users.return_value.drafts.return_value
+    drafts.create.return_value.execute.return_value = draft
+
+    result = gmail.create_draft(**params)
+
+    gmail._create_message.assert_called_once_with(**params)
+    drafts.create.assert_called_once_with(
+        userId='account@example.com',
+        body={'message': {'raw': 'encoded-message'}},
+    )
+    assert result is draft
+
+
 def test_html_payload_handles_deeply_nested_content():
     nested = '<div>' * 1000 + 'message' + '</div>' * 1000
     payload = {


### PR DESCRIPTION
- add `Gmail.create_draft()` with the same message options as `send_message()`
- document draft creation in the README

Closes #115.