### PR TITLE
[feature] Add metadata-only message retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ messages = gmail.get_unread_inbox()
 # Starred messages
 messages = gmail.get_starred_messages()
 
+# Message headers without bodies or attachments
+messages = gmail.get_messages(metadata_only=True)
+print(messages[0].size_estimate)
+
 # ...and many more easy to use functions can be found in gmail.py!
 
 # Print them out!

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -574,7 +574,8 @@ class Gmail(object):
         labels: Optional[List[Label]] = None,
         query: str = '',
         attachments: str = 'reference',
-        include_spam_trash: bool = False
+        include_spam_trash: bool = False,
+        metadata_only: bool = False
     ) -> List[Message]:
         """
         Gets messages from your account.
@@ -590,6 +591,8 @@ class Gmail(object):
                 downloads the attachment data to store locally. Default
                 'reference'.
             include_spam_trash: whether to include messages from spam or trash.
+            metadata_only: whether to retrieve headers without message bodies
+                or attachments. Default False.
 
         Returns:
             A list of message objects.
@@ -631,8 +634,12 @@ class Gmail(object):
 
                 message_refs.extend(response['messages'])
 
-            return self._get_messages_from_refs(user_id, message_refs,
-                                                attachments)
+            return self._get_messages_from_refs(
+                user_id,
+                message_refs,
+                attachments,
+                metadata_only=metadata_only
+            )
 
         except HttpError as error:
             # Pass along the error
@@ -745,7 +752,8 @@ class Gmail(object):
         user_id: str,
         message_refs: List[dict],
         attachments: str = 'reference',
-        parallel: bool = True
+        parallel: bool = True,
+        metadata_only: bool = False
     ) -> List[Message]:
         """
         Retrieves the actual messages from a list of references.
@@ -761,6 +769,8 @@ class Gmail(object):
             parallel: Whether to retrieve messages in parallel. Default true.
                 Currently parallelization is always on, since there is no
                 reason to do otherwise.
+            metadata_only: Whether to retrieve headers without message bodies
+                or attachments. Default False.
 
 
         Returns:
@@ -776,7 +786,8 @@ class Gmail(object):
             return []
 
         if not parallel:
-            return [self._build_message_from_ref(user_id, ref, attachments)
+            return [self._build_message_from_ref(
+                        user_id, ref, attachments, metadata_only=metadata_only)
                     for ref in message_refs]
 
         max_num_threads = 12  # empirically chosen, prevents throttling
@@ -794,7 +805,10 @@ class Gmail(object):
                 end = min(len(message_refs), (thread_num + 1) * batch_size)
                 return [
                     gmail._build_message_from_ref(
-                        user_id, message_refs[i], attachments
+                        user_id,
+                        message_refs[i],
+                        attachments,
+                        metadata_only=metadata_only
                     )
                     for i in range(start, end)
                 ]
@@ -808,7 +822,8 @@ class Gmail(object):
         self,
         user_id: str,
         message_ref: dict,
-        attachments: str = 'reference'
+        attachments: str = 'reference',
+        metadata_only: bool = False
     ) -> Message:
         """
         Creates a Message object from a reference.
@@ -822,6 +837,8 @@ class Gmail(object):
                 information but does not download the data, and 'download' which
                 downloads the attachment data to store locally. Default
                 'reference'.
+            metadata_only: Whether to retrieve headers without message bodies
+                or attachments. Default False.
 
         Returns:
             The Message object.
@@ -834,8 +851,11 @@ class Gmail(object):
 
         try:
             # Get message JSON
+            params = {'userId': user_id, 'id': message_ref['id']}
+            if metadata_only:
+                params['format'] = 'metadata'
             message = self.service.users().messages().get(
-                userId=user_id, id=message_ref['id']
+                **params
             ).execute()
 
         except HttpError as error:
@@ -849,7 +869,7 @@ class Gmail(object):
             if 'labelIds' in message:
                 user_labels = {x.id: x for x in self.list_labels(user_id=user_id)}
                 label_ids = [user_labels[x] for x in message['labelIds']]
-            snippet = html.unescape(message['snippet'])
+            snippet = html.unescape(message.get('snippet', ''))
 
             payload = message['payload']
             headers = payload['headers']
@@ -881,7 +901,7 @@ class Gmail(object):
 
                 msg_hdrs[hdr['name']] = hdr['value']
 
-            parts = self._evaluate_message_payload(
+            parts = [] if metadata_only else self._evaluate_message_payload(
                 payload, user_id, message_ref['id'], attachments
             )
 
@@ -922,7 +942,8 @@ class Gmail(object):
                 attms,
                 msg_hdrs,
                 cc,
-                bcc
+                bcc,
+                size_estimate=message.get('sizeEstimate')
             )
 
     def _evaluate_message_payload(

--- a/simplegmail/message.py
+++ b/simplegmail/message.py
@@ -40,6 +40,7 @@ class Message(object):
         headers: a dict of header values. Default {}
         cc: who the message was cc'd on the message.
         bcc: who the message was bcc'd on the message.
+        size_estimate: the estimated message size in bytes. Default None.
 
     Attributes:
         _service (googleapiclient.discovery.Resource): the Gmail service object.
@@ -57,6 +58,7 @@ class Message(object):
         headers (dict): a dict of header values.
         cc (List[str]): who the message was cc'd on the message.
         bcc (List[str]): who the message was bcc'd on the message.
+        size_estimate (int): the estimated message size in bytes.
 
     """
 
@@ -78,7 +80,8 @@ class Message(object):
         attachments: Optional[List[Attachment]] = None,
         headers: Optional[dict] = None,
         cc: Optional[List[str]] = None,
-        bcc: Optional[List[str]] = None
+        bcc: Optional[List[str]] = None,
+        size_estimate: Optional[int] = None
     ) -> None:
         self._service = service
         self.creds = creds
@@ -97,6 +100,7 @@ class Message(object):
         self.headers = headers or {}
         self.cc = cc or []
         self.bcc = bcc or []
+        self.size_estimate = size_estimate
 
     @property
     def service(self) -> 'googleapiclient.discovery.Resource':

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -257,6 +257,82 @@ def test_create_draft_uses_message_builder_and_returns_api_resource():
     assert result is draft
 
 
+def test_get_messages_passes_metadata_option_to_message_retrieval():
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+    refs = [{'id': 'message-id'}]
+    messages = gmail._service.users.return_value.messages.return_value
+    messages.list.return_value.execute.return_value = {'messages': refs}
+    gmail._get_messages_from_refs = MagicMock(return_value=[])
+
+    gmail.get_messages(metadata_only=True)
+
+    gmail._get_messages_from_refs.assert_called_once_with(
+        'me', refs, 'reference', metadata_only=True
+    )
+
+
+def test_builds_metadata_message_without_parsing_body():
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+    messages = gmail._service.users.return_value.messages.return_value
+    messages.get.return_value.execute.return_value = {
+        'id': 'message-id',
+        'threadId': 'thread-id',
+        'sizeEstimate': 1234,
+        'payload': {
+            'headers': [
+                {'name': 'From', 'value': 'sender@example.com'},
+                {'name': 'To', 'value': 'recipient@example.com'},
+                {'name': 'Subject', 'value': 'Subject'},
+                {'name': 'Date', 'value': 'Date'},
+            ],
+        },
+    }
+
+    message = gmail._build_message_from_ref(
+        'me', {'id': 'message-id'}, metadata_only=True
+    )
+
+    messages.get.assert_called_once_with(
+        userId='me', id='message-id', format='metadata'
+    )
+    assert message.sender == 'sender@example.com'
+    assert message.recipient == 'recipient@example.com'
+    assert message.subject == 'Subject'
+    assert message.date == 'Date'
+    assert message.size_estimate == 1234
+    assert message.plain is None
+    assert message.html is None
+    assert message.attachments == []
+
+
+def test_full_message_retrieval_remains_the_default():
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+    messages = gmail._service.users.return_value.messages.return_value
+    messages.get.return_value.execute.return_value = {
+        'id': 'message-id',
+        'threadId': 'thread-id',
+        'snippet': 'Snippet',
+        'payload': {
+            'headers': [],
+            'mimeType': 'text/plain',
+            'body': {
+                'data': base64.urlsafe_b64encode(b'Body').decode(),
+            },
+        },
+    }
+
+    message = gmail._build_message_from_ref('me', {'id': 'message-id'})
+
+    messages.get.assert_called_once_with(userId='me', id='message-id')
+    assert message.plain == 'Body'
+
+
 def test_html_payload_handles_deeply_nested_content():
     nested = '<div>' * 1000 + 'message' + '</div>' * 1000
     payload = {
@@ -280,7 +356,8 @@ def test_parallel_retrieval_preserves_order_and_closes_services():
     message_refs = [{'id': str(i)} for i in range(21)]
     workers = []
 
-    def build_message(user_id, message_ref, attachments):
+    def build_message(user_id, message_ref, attachments, metadata_only=False):
+        assert metadata_only is True
         return message_ref['id']
 
     with patch(
@@ -288,7 +365,11 @@ def test_parallel_retrieval_preserves_order_and_closes_services():
         side_effect=lambda **_: build_worker(workers, build_message),
     ) as gmail_class:
         messages = Gmail._get_messages_from_refs(
-            gmail, 'me', message_refs, attachments='ignore'
+            gmail,
+            'me',
+            message_refs,
+            attachments='ignore',
+            metadata_only=True,
         )
 
     assert messages == [ref['id'] for ref in message_refs]
@@ -302,7 +383,7 @@ def test_parallel_retrieval_propagates_worker_errors_and_closes_services():
     workers = []
     error = RuntimeError('download failed')
 
-    def build_message(user_id, message_ref, attachments):
+    def build_message(user_id, message_ref, attachments, metadata_only=False):
         if message_ref['id'] == '6':
             raise error
         return message_ref['id']


### PR DESCRIPTION
- add a `metadata_only` option to `Gmail.get_messages()` to request Gmail’s metadata format without downloading message bodies or attachments
- expose Gmail’s estimated message size through `Message.size_estimate`
- document the new option in the README

Full message retrieval remains the default.

Closes #117.