### PR TITLE
[feature] Add max message retrieval and reuse label metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ query_params = {
 
 messages = gmail.get_messages(query=construct_query(query_params))
 
+# Stop after the first 10 matching messages
+messages = gmail.get_messages(
+  query=construct_query(query_params),
+  max_results=10
+)
+
 # We could have also accomplished this with
 # messages = gmail.get_unread_messages(query=construct_query(newer_than=(2, "day"), labels=[["Work"], ["Homework", "CS"]]))
 # There are many, many different ways of achieving the same result with search.

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -60,6 +60,8 @@ class Gmail(object):
         'https://www.googleapis.com/auth/gmail.modify',
         'https://www.googleapis.com/auth/gmail.settings.basic'
     ]
+    # Gmail's users.messages.list API allows at most 500 results per page.
+    _MAX_MESSAGES_PER_PAGE = 500
 
     # If you don't have a client secret file, follow the instructions at:
     # https://developers.google.com/gmail/api/quickstart/python
@@ -575,7 +577,8 @@ class Gmail(object):
         query: str = '',
         attachments: str = 'reference',
         include_spam_trash: bool = False,
-        metadata_only: bool = False
+        metadata_only: bool = False,
+        max_results: Optional[int] = None
     ) -> List[Message]:
         """
         Gets messages from your account.
@@ -593,11 +596,14 @@ class Gmail(object):
             include_spam_trash: whether to include messages from spam or trash.
             metadata_only: whether to retrieve headers without message bodies
                 or attachments. Default False.
+            max_results: the maximum total number of messages to retrieve.
+                Default None, which retrieves every matching message.
 
         Returns:
             A list of message objects.
 
         Raises:
+            ValueError: `max_results` is not a positive integer.
             googleapiclient.errors.HttpError: There was an error executing the
                 HTTP request.
 
@@ -605,34 +611,48 @@ class Gmail(object):
 
         if labels is None:
             labels = []
+        if max_results is not None and (
+            isinstance(max_results, bool)
+            or not isinstance(max_results, int)
+            or max_results < 1
+        ):
+            raise ValueError('max_results must be a positive integer')
 
         labels_ids = [
             lbl.id if isinstance(lbl, Label) else lbl for lbl in labels
         ]
+        list_params = {
+            'userId': user_id,
+            'q': query,
+            'labelIds': labels_ids,
+            'includeSpamTrash': include_spam_trash,
+        }
+        if max_results is not None:
+            list_params['maxResults'] = min(
+                max_results, self._MAX_MESSAGES_PER_PAGE
+            )
 
         try:
             response = self.service.users().messages().list(
-                userId=user_id,
-                q=query,
-                labelIds=labels_ids,
-                includeSpamTrash=include_spam_trash
+                **list_params
             ).execute()
 
-            message_refs = []
-            if 'messages' in response:  # ensure request was successful
-                message_refs.extend(response['messages'])
+            message_refs = list(response.get('messages', []))
 
-            while 'nextPageToken' in response:
-                page_token = response['nextPageToken']
+            while response.get('nextPageToken') and (
+                max_results is None or len(message_refs) < max_results
+            ):
+                list_params['pageToken'] = response['nextPageToken']
+                if max_results is not None:
+                    list_params['maxResults'] = min(
+                        max_results - len(message_refs),
+                        self._MAX_MESSAGES_PER_PAGE
+                    )
                 response = self.service.users().messages().list(
-                    userId=user_id,
-                    q=query,
-                    labelIds=labels_ids,
-                    includeSpamTrash=include_spam_trash,
-                    pageToken=page_token
+                    **list_params
                 ).execute()
 
-                message_refs.extend(response['messages'])
+                message_refs.extend(response.get('messages', []))
 
             return self._get_messages_from_refs(
                 user_id,
@@ -785,9 +805,15 @@ class Gmail(object):
         if not message_refs:
             return []
 
+        user_labels = {
+            lbl.id: lbl for lbl in self.list_labels(user_id=user_id)
+        }
+
         if not parallel:
             return [self._build_message_from_ref(
-                        user_id, ref, attachments, metadata_only=metadata_only)
+                        user_id, ref, attachments,
+                        metadata_only=metadata_only,
+                        user_labels=user_labels)
                     for ref in message_refs]
 
         max_num_threads = 12  # empirically chosen, prevents throttling
@@ -808,7 +834,8 @@ class Gmail(object):
                         user_id,
                         message_refs[i],
                         attachments,
-                        metadata_only=metadata_only
+                        metadata_only=metadata_only,
+                        user_labels=user_labels
                     )
                     for i in range(start, end)
                 ]
@@ -823,7 +850,8 @@ class Gmail(object):
         user_id: str,
         message_ref: dict,
         attachments: str = 'reference',
-        metadata_only: bool = False
+        metadata_only: bool = False,
+        user_labels: Optional[dict] = None
     ) -> Message:
         """
         Creates a Message object from a reference.
@@ -839,6 +867,7 @@ class Gmail(object):
                 'reference'.
             metadata_only: Whether to retrieve headers without message bodies
                 or attachments. Default False.
+            user_labels: Labels keyed by ID. Loaded if not provided.
 
         Returns:
             The Message object.
@@ -867,7 +896,10 @@ class Gmail(object):
             thread_id = message['threadId']
             label_ids = []
             if 'labelIds' in message:
-                user_labels = {x.id: x for x in self.list_labels(user_id=user_id)}
+                if user_labels is None:
+                    user_labels = {
+                        x.id: x for x in self.list_labels(user_id=user_id)
+                    }
                 label_ids = [user_labels[x] for x in message['labelIds']]
             snippet = html.unescape(message.get('snippet', ''))
 

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from simplegmail import label
 from simplegmail.gmail import Gmail
 
 
@@ -261,16 +262,70 @@ def test_get_messages_passes_metadata_option_to_message_retrieval():
     gmail = build_gmail()
     gmail.creds.expired = False
     gmail._service = MagicMock()
-    refs = [{'id': 'message-id'}]
+    refs = [{'id': 'message-1'}, {'id': 'message-2'}]
     messages = gmail._service.users.return_value.messages.return_value
-    messages.list.return_value.execute.return_value = {'messages': refs}
+    messages.list.return_value.execute.side_effect = [
+        {'messages': refs[:1], 'nextPageToken': 'next'},
+        {'messages': refs[1:]},
+    ]
     gmail._get_messages_from_refs = MagicMock(return_value=[])
 
     gmail.get_messages(metadata_only=True)
 
+    assert messages.list.call_args_list == [
+        call(userId='me', q='', labelIds=[], includeSpamTrash=False),
+        call(
+            userId='me', q='', labelIds=[], includeSpamTrash=False,
+            pageToken='next',
+        ),
+    ]
     gmail._get_messages_from_refs.assert_called_once_with(
         'me', refs, 'reference', metadata_only=True
     )
+
+
+def test_get_messages_limits_results_across_pages():
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+    messages = gmail._service.users.return_value.messages.return_value
+    first_page = [{'id': str(i)} for i in range(500)]
+    last_page = [{'id': '500'}]
+    messages.list.return_value.execute.side_effect = [
+        {'messages': first_page, 'nextPageToken': 'next'},
+        {'messages': last_page, 'nextPageToken': 'unused'},
+    ]
+    gmail._get_messages_from_refs = MagicMock(return_value=[])
+
+    gmail.get_messages(max_results=501)
+
+    assert messages.list.call_args_list == [
+        call(
+            userId='me', q='', labelIds=[], includeSpamTrash=False,
+            maxResults=500,
+        ),
+        call(
+            userId='me', q='', labelIds=[], includeSpamTrash=False,
+            maxResults=1, pageToken='next',
+        ),
+    ]
+    gmail._get_messages_from_refs.assert_called_once_with(
+        'me', first_page + last_page, 'reference', metadata_only=False
+    )
+
+
+@pytest.mark.parametrize('max_results', [0, -1, 1.5, '1', True])
+def test_get_messages_rejects_invalid_max_results(max_results):
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+
+    with pytest.raises(
+        ValueError, match='max_results must be a positive integer'
+    ):
+        gmail.get_messages(max_results=max_results)
+
+    gmail._service.users.assert_not_called()
 
 
 def test_builds_metadata_message_without_parsing_body():
@@ -317,6 +372,7 @@ def test_full_message_retrieval_remains_the_default():
     messages.get.return_value.execute.return_value = {
         'id': 'message-id',
         'threadId': 'thread-id',
+        'labelIds': ['INBOX'],
         'snippet': 'Snippet',
         'payload': {
             'headers': [],
@@ -326,11 +382,18 @@ def test_full_message_retrieval_remains_the_default():
             },
         },
     }
+    gmail.list_labels = MagicMock()
 
-    message = gmail._build_message_from_ref('me', {'id': 'message-id'})
+    message = gmail._build_message_from_ref(
+        'me',
+        {'id': 'message-id'},
+        user_labels={'INBOX': label.INBOX},
+    )
 
     messages.get.assert_called_once_with(userId='me', id='message-id')
+    gmail.list_labels.assert_not_called()
     assert message.plain == 'Body'
+    assert message.label_ids == [label.INBOX]
 
 
 def test_html_payload_handles_deeply_nested_content():
@@ -353,11 +416,20 @@ def test_html_payload_handles_deeply_nested_content():
 
 def test_parallel_retrieval_preserves_order_and_closes_services():
     gmail = build_gmail()
+    gmail.list_labels = MagicMock(return_value=[label.INBOX])
     message_refs = [{'id': str(i)} for i in range(21)]
     workers = []
+    label_maps = []
 
-    def build_message(user_id, message_ref, attachments, metadata_only=False):
+    def build_message(
+        user_id,
+        message_ref,
+        attachments,
+        metadata_only=False,
+        user_labels=None,
+    ):
         assert metadata_only is True
+        label_maps.append(user_labels)
         return message_ref['id']
 
     with patch(
@@ -373,17 +445,26 @@ def test_parallel_retrieval_preserves_order_and_closes_services():
         )
 
     assert messages == [ref['id'] for ref in message_refs]
+    gmail.list_labels.assert_called_once_with(user_id='me')
+    assert label_maps == [{'INBOX': label.INBOX}] * len(message_refs)
     assert gmail_class.call_count == 3
     assert all(worker.service.close.call_count == 1 for worker in workers)
 
 
 def test_parallel_retrieval_propagates_worker_errors_and_closes_services():
     gmail = build_gmail()
+    gmail.list_labels = MagicMock(return_value=[])
     message_refs = [{'id': str(i)} for i in range(11)]
     workers = []
     error = RuntimeError('download failed')
 
-    def build_message(user_id, message_ref, attachments, metadata_only=False):
+    def build_message(
+        user_id,
+        message_ref,
+        attachments,
+        metadata_only=False,
+        user_labels=None,
+    ):
         if message_ref['id'] == '6':
             raise error
         return message_ref['id']


### PR DESCRIPTION
- Add an optional max_results argument to get_messages()
- Apply the limit across paginated Gmail API responses
- Fetch labels once per retrieval instead of once per message
- Document the new option and add regression coverage

This is backward compatible: omitting max_results continues retrieving all matching messages.

Closes #52
Closes #123