### PR TITLE
[feature] Allow saving attachments to directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,11 @@ message = messages[0]
 if message.attachments:
     for attm in message.attachments:
         print('File: ' + attm.filename)
-        attm.save()  # downloads and saves each attachment under it's stored
+        attm.save()  # downloads and saves each attachment under its stored
                      # filename. You can download without saving with `attm.download()`
+
+        # An existing directory can also be supplied.
+        attm.save(filepath='downloads', overwrite=True)
 
 ```
 

--- a/simplegmail/attachment.py
+++ b/simplegmail/attachment.py
@@ -81,8 +81,8 @@ class Attachment(object):
         Saves the attachment. Downloads file data if not downloaded.
         
         Args:
-            filepath: where to save the attachment. Default None, which uses 
-                the filename stored.
+            filepath: File or existing directory where the attachment should
+                be saved. Default None, which uses the stored filename.
             overwrite: whether to overwrite existing files. Default False.
         
         Raises:
@@ -93,6 +93,8 @@ class Attachment(object):
         
         if filepath is None:
             filepath = self.filename
+        elif os.path.isdir(filepath):
+            filepath = os.path.join(filepath, os.path.basename(self.filename))
 
         if self.data is None:
             self.download()
@@ -105,4 +107,3 @@ class Attachment(object):
 
         with open(filepath, 'wb') as f:
             f.write(self.data)
-

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from simplegmail.attachment import Attachment
+
+
+def build_attachment(filename='attachment.txt', data=b'attachment data'):
+    return Attachment(
+        service=MagicMock(),
+        user_id='me',
+        msg_id='message-id',
+        att_id='attachment-id',
+        filename=filename,
+        filetype='text/plain',
+        data=data,
+    )
+
+
+def test_save_accepts_existing_directory(tmp_path):
+    destination = tmp_path / 'downloads'
+    destination.mkdir()
+
+    build_attachment().save(filepath=str(destination))
+
+    assert (destination / 'attachment.txt').read_bytes() == b'attachment data'
+
+
+def test_save_preserves_full_filepath_behavior(tmp_path):
+    destination = tmp_path / 'renamed.txt'
+
+    build_attachment().save(filepath=str(destination))
+
+    assert destination.read_bytes() == b'attachment data'
+
+
+def test_save_uses_filename_basename_with_directory(tmp_path):
+    destination = tmp_path / 'downloads'
+    destination.mkdir()
+
+    build_attachment(filename='../attachment.txt').save(
+        filepath=str(destination)
+    )
+
+    assert (destination / 'attachment.txt').read_bytes() == b'attachment data'
+    assert not (tmp_path / 'attachment.txt').exists()
+
+
+def test_save_directory_respects_overwrite_option(tmp_path):
+    destination = tmp_path / 'downloads'
+    destination.mkdir()
+    saved_attachment = destination / 'attachment.txt'
+    saved_attachment.write_bytes(b'existing data')
+    attachment = build_attachment()
+
+    with pytest.raises(FileExistsError):
+        attachment.save(filepath=str(destination))
+
+    assert saved_attachment.read_bytes() == b'existing data'
+
+    attachment.save(filepath=str(destination), overwrite=True)
+
+    assert saved_attachment.read_bytes() == b'attachment data'


### PR DESCRIPTION
- Allow Attachment.save() to accept an existing directory and save the attachment under its stored filename within that directory

Backwards compatible.

Closes #103