### PR TITLE
[docs] Document timestamp-based Gmail queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ if message.attachments:
 ### Retrieving messages (advanced, with queries!):
 
 ```python
+from datetime import datetime, timedelta, timezone
+
 from simplegmail import Gmail
 from simplegmail.query import construct_query
 
@@ -277,6 +279,13 @@ messages = gmail.get_messages(query=construct_query(query_params))
 messages = gmail.get_messages(
   query=construct_query(query_params),
   max_results=10
+)
+
+# Gmail's newer_than operator supports days, months, and years. For shorter
+# periods, use a Unix timestamp with after.
+ten_minutes_ago = datetime.now(timezone.utc) - timedelta(minutes=10)
+messages = gmail.get_messages(
+  query=construct_query(after=int(ten_minutes_ago.timestamp()))
 )
 
 # We could have also accomplished this with

--- a/simplegmail/query.py
+++ b/simplegmail/query.py
@@ -76,11 +76,15 @@ def construct_query(*query_dicts, **query_terms) -> str:
 
         bcc (str): Recipient in the bcc field. E.g.: bcc='jane@email.com'
 
-        before (str): The message was sent before a date.
+        before (Union[str, int]): The message was sent before a date or Unix
+            timestamp.
             E.g.: before='2004/04/27'
+                  before=1083024000
 
-        after (str): The message was sent after a date.
+        after (Union[str, int]): The message was sent after a date or Unix
+            timestamp.
             E.g.: after='2004/04/27'
+                  after=1083024000
 
         older_than (Tuple[int, str]): The message was sent before a given
             time period.
@@ -419,12 +423,12 @@ def _bcc(recipient: str) -> str:
     return f'bcc:{recipient}'
 
 
-def _after(date: str) -> str:
+def _after(date: Union[str, int]) -> str:
     """
     Returns a query term matching messages sent after a given date.
 
     Args:
-        date: The date messages must be sent after.
+        date: The date or Unix timestamp messages must be sent after.
 
     Returns:
         The query string.
@@ -434,12 +438,12 @@ def _after(date: str) -> str:
     return f'after:{date}'
 
 
-def _before(date: str) -> str:
+def _before(date: Union[str, int]) -> str:
     """
     Returns a query term matching messages sent before a given date.
 
     Args:
-        date: The date messages must be sent before.
+        date: The date or Unix timestamp messages must be sent before.
 
     Returns:
         The query string.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -97,6 +97,13 @@ class TestQuery(object):
     def test_falsey_non_boolean_terms_are_not_negated(self):
         assert query.construct_query(subject='') == 'subject:'
 
+    def test_date_terms_accept_unix_timestamps(self):
+        query_string = query.construct_query(
+            after=1692211200, before=1692211800
+        )
+
+        assert query_string == '(after:1692211200 before:1692211800)'
+
     def test_false_boolean_terms_in_or_queries_are_negated(self):
         query_string = query.construct_query(
             {'starred': False}, {'attachment': False}


### PR DESCRIPTION
- Document Unix timestamp support for after and before queries
- Add a supported example for retrieving messages from the last ten minutes

Closes #96