### PR TITLE
[feature] Support sending EmailMessage objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ params = {
 message = gmail.send_message(**params)  # equivalent to send_message(to="you@youremail.com", sender=...)
 ```
 
+### Send a standard library `EmailMessage`:
+
+```python
+from email.message import EmailMessage
+
+from simplegmail import Gmail
+
+gmail = Gmail()
+message = EmailMessage()
+message['To'] = 'you@youremail.com'
+message['From'] = 'me@myemail.com'
+message['Subject'] = 'An EmailMessage'
+message.set_content("Built with Python's standard email library.")
+
+sent_message = gmail.send_email_message(message)
+```
+
 ### Create a draft:
 
 ```python

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -8,6 +8,7 @@ attachments) and retrieving mail with the full suite of Gmail search options.
 
 import base64
 from concurrent.futures import ThreadPoolExecutor
+from email.message import EmailMessage
 from email.mime.audio       import MIMEAudio
 from email.mime.application import MIMEApplication
 from email.mime.base        import MIMEBase
@@ -200,15 +201,31 @@ class Gmail(object):
             sender, to, subject, msg_html, msg_plain, cc=cc, bcc=bcc,
             attachments=attachments, signature=signature, user_id=user_id
         )
+        return self._send_message(msg, user_id)
 
-        try:
-            req = self.service.users().messages().send(userId='me', body=msg)
-            res = req.execute()
-            return self._build_message_from_ref(user_id, res, 'reference')
+    def send_email_message(
+        self,
+        message: EmailMessage,
+        user_id: str = 'me'
+    ) -> Message:
+        """Sends a standard library EmailMessage.
 
-        except HttpError as error:
-            # Pass along the error
-            raise error
+        Args:
+            message: The fully constructed email message to send.
+            user_id: The address of the sending account. 'me' for the default
+                address associated with the account.
+
+        Returns:
+            The Message object representing the sent message.
+
+        Raises:
+            googleapiclient.errors.HttpError: There was an error executing the
+                HTTP request.
+
+        """
+
+        raw = base64.urlsafe_b64encode(message.as_bytes()).decode()
+        return self._send_message({'raw': raw}, user_id)
 
     def create_draft(
         self,
@@ -1061,6 +1078,13 @@ class Gmail(object):
             return ret
 
         return []
+
+    def _send_message(self, message: dict, user_id: str) -> Message:
+        res = self.service.users().messages().send(
+            userId=user_id,
+            body=message
+        ).execute()
+        return self._build_message_from_ref(user_id, res, 'reference')
 
     def _create_message(
         self,

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -1,8 +1,10 @@
 import base64
+from email.message import EmailMessage
 import json
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from googleapiclient.errors import HttpError
 
 from simplegmail import label
 from simplegmail.gmail import Gmail
@@ -225,6 +227,77 @@ def test_service_refreshes_expired_credentials():
 
     assert service is gmail._service
     gmail.creds.refresh.assert_called_once_with(request)
+
+
+def test_send_message_uses_existing_builder_and_shared_sender():
+    gmail = build_gmail()
+    message_resource = {'raw': 'encoded-message'}
+    sent_message = object()
+    gmail._create_message = MagicMock(return_value=message_resource)
+    gmail._send_message = MagicMock(return_value=sent_message)
+
+    result = gmail.send_message(
+        sender='sender@example.com',
+        to='recipient@example.com',
+        user_id='account@example.com',
+    )
+
+    gmail._create_message.assert_called_once()
+    gmail._send_message.assert_called_once_with(
+        message_resource, 'account@example.com'
+    )
+    assert result is sent_message
+
+
+def test_send_email_message_encodes_and_sends_mime_message():
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+    message_api = gmail._service.users.return_value.messages.return_value
+    message_ref = {'id': 'message-id'}
+    message_api.send.return_value.execute.return_value = message_ref
+    sent_message = object()
+    gmail._build_message_from_ref = MagicMock(return_value=sent_message)
+    message = EmailMessage()
+    message['From'] = 'sender@example.com'
+    message['To'] = 'recipient@example.com'
+    message['Subject'] = 'Subject'
+    message.set_content('Body')
+    message.add_attachment(
+        b'attachment',
+        maintype='application',
+        subtype='octet-stream',
+        filename='attachment.bin',
+    )
+    encoded_message = base64.urlsafe_b64encode(message.as_bytes()).decode()
+
+    result = gmail.send_email_message(
+        message, user_id='account@example.com'
+    )
+
+    message_api.send.assert_called_once_with(
+        userId='account@example.com',
+        body={'raw': encoded_message},
+    )
+    gmail._build_message_from_ref.assert_called_once_with(
+        'account@example.com', message_ref, 'reference'
+    )
+    assert result is sent_message
+
+
+def test_send_email_message_propagates_api_errors():
+    gmail = build_gmail()
+    gmail.creds.expired = False
+    gmail._service = MagicMock()
+    response = MagicMock(status=400, reason='Bad Request')
+    error = HttpError(response, b'{}')
+    message_api = gmail._service.users.return_value.messages.return_value
+    message_api.send.return_value.execute.side_effect = error
+
+    with pytest.raises(HttpError) as raised:
+        gmail.send_email_message(EmailMessage())
+
+    assert raised.value is error
 
 
 def test_create_draft_uses_message_builder_and_returns_api_resource():


### PR DESCRIPTION
- Add Gmail.send_email_message() for standard-library EmailMessage objects
- Add usage documentation and regression tests

The change is backwards compatible.

Closes #71