### PR TITLE
[feature] Support injected Google credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ To print the authorization URL without opening a browser, use
 `Gmail(noauth_local_webserver=True)`. Google no longer supports the old manual
 copy/paste flow, so authorization still redirects to a local callback server.
 
+For deployments that store authorized-user JSON in an environment variable or
+secret manager, construct `google-auth` credentials and pass them directly:
+
+```python
+import json
+import os
+
+from google.oauth2.credentials import Credentials
+from simplegmail import Gmail
+
+credentials = Credentials.from_authorized_user_info(
+    json.loads(os.environ['GMAIL_TOKEN'])
+)
+gmail = Gmail(credentials=credentials)
+```
+
+`GMAIL_TOKEN` is an application-defined name containing the JSON stored in
+`gmail_token.json`. Keep OAuth credentials and refresh tokens in secure storage
+and never commit them to source control.
+
 You are now good to go!
 
 Note about authentication method: I have opted not to use a username-password 

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -49,6 +49,8 @@ class Gmail(object):
             user necessarily present. Either 'online' or 'offline'.
         noauth_local_webserver: Whether to suppress opening the authorization
             URL in a browser. The local callback server is always required.
+        credentials: Existing google-auth credentials. When provided, file-based
+            authentication is skipped.
 
     Attributes:
         client_secret_file (str): The name of the user's client secret file.
@@ -74,17 +76,17 @@ class Gmail(object):
         creds_file: str = 'gmail_token.json',
         access_type: str = 'offline',
         noauth_local_webserver: bool = False,
-        _creds: Optional[GoogleCredentials] = None,
+        credentials: Optional[GoogleCredentials] = None,
     ) -> None:
         self.client_secret_file = client_secret_file
         self.creds_file = creds_file
 
-        if _creds is None:
+        if credentials is None:
             self.creds = self._get_credentials(
                 access_type, noauth_local_webserver
             )
         else:
-            self.creds = _creds
+            self.creds = credentials
 
         self._service = build(
             'gmail', 'v1', credentials=self.creds, cache_discovery=False
@@ -842,7 +844,7 @@ class Gmail(object):
         batch_size = math.ceil(len(message_refs) / num_threads)
 
         def download_batch(thread_num):
-            gmail = Gmail(_creds=self.creds)
+            gmail = Gmail(credentials=self.creds)
             try:
                 start = thread_num * batch_size
                 end = min(len(message_refs), (thread_num + 1) * batch_size)

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -44,11 +44,13 @@ def test_uses_injected_credentials_without_loading_token_file():
     creds = build_credentials()
     service = MagicMock()
 
-    with patch('simplegmail.gmail.build', return_value=service) as build:
-        gmail = Gmail(_creds=creds)
+    with patch.object(Gmail, '_get_credentials') as load:
+        with patch('simplegmail.gmail.build', return_value=service) as build:
+            gmail = Gmail(credentials=creds)
 
     assert gmail.creds is creds
     assert gmail.service is service
+    load.assert_not_called()
     build.assert_called_once_with(
         'gmail', 'v1', credentials=creds, cache_discovery=False
     )
@@ -605,7 +607,7 @@ def test_parallel_retrieval_preserves_order_and_closes_services():
     assert messages == [ref['id'] for ref in message_refs]
     gmail.list_labels.assert_called_once_with(user_id='me')
     assert label_maps == [{'INBOX': label.INBOX}] * len(message_refs)
-    assert gmail_class.call_count == 3
+    assert gmail_class.call_args_list == [call(credentials=gmail.creds)] * 3
     assert all(worker.service.close.call_count == 1 for worker in workers)
 
 


### PR DESCRIPTION
- Add a public Gmail(credentials=...) constructor argument, remove private `_creds` arguments
- Allow credentials to be loaded from environment variables, Docker secrets, databases, or secret managers
- Document loading authorized-user JSON from an environment variable

The library does not impose environment-variable names or secret-storage policies; callers remain responsible for loading credentials securely.

Not backwards-compatible: removes private, undocumented argument `_creds`.

Closes #49