### PR TITLE
[feature] Support threaded replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,25 @@ message.set_content("Built with Python's standard email library.")
 sent_message = gmail.send_email_message(message)
 ```
 
+### Reply to a message in the same thread:
+
+```python
+from simplegmail import Gmail
+
+gmail = Gmail()
+original = gmail.get_messages(query='subject:"Original subject"')[0]
+
+reply = gmail.send_message(
+    sender='me@myemail.com',
+    to=original.sender,
+    msg_plain='Thanks for your message.',
+    reply_to=original,
+)
+```
+
+The original subject is reused automatically because Gmail requires matching
+subjects when adding a reply to an existing thread.
+
 ### Create a draft:
 
 ```python

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -169,7 +169,8 @@ class Gmail(object):
         bcc: Optional[List[str]] = None,
         attachments: Optional[List[str]] = None,
         signature: bool = False,
-        user_id: str = 'me'
+        user_id: str = 'me',
+        reply_to: Optional[Message] = None,
     ) -> Message:
         """
         Sends an email.
@@ -189,11 +190,15 @@ class Gmail(object):
                 message.
             user_id: The address of the sending account. 'me' for the
                 default address associated with the account.
+            reply_to: The message being replied to. When provided, the new
+                message is sent in the same Gmail thread.
 
         Returns:
             The Message object representing the sent message.
 
         Raises:
+            ValueError: The reply lacks the metadata required for threading,
+                or its subject does not match the original message.
             googleapiclient.errors.HttpError: There was an error executing the
                 HTTP request.
 
@@ -201,7 +206,8 @@ class Gmail(object):
 
         msg = self._create_message(
             sender, to, subject, msg_html, msg_plain, cc=cc, bcc=bcc,
-            attachments=attachments, signature=signature, user_id=user_id
+            attachments=attachments, signature=signature, user_id=user_id,
+            reply_to=reply_to,
         )
         return self._send_message(msg, user_id)
 
@@ -1099,7 +1105,8 @@ class Gmail(object):
         bcc: List[str] = None,
         attachments: List[str] = None,
         signature: bool = False,
-        user_id: str = 'me'
+        user_id: str = 'me',
+        reply_to: Optional[Message] = None,
     ) -> dict:
         """
         Creates the raw email message to be sent.
@@ -1117,6 +1124,7 @@ class Gmail(object):
             signature: Whether the account signature should be added to the
                 message. Will add the signature to your HTML message only, or a
                 create a HTML message if none exists.
+            reply_to: The message being replied to.
 
         Returns:
             The message dict.
@@ -1126,7 +1134,32 @@ class Gmail(object):
         msg = MIMEMultipart('mixed' if attachments else 'alternative')
         msg['To'] = to
         msg['From'] = sender
-        msg['Subject'] = subject
+
+        if reply_to is None:
+            msg['Subject'] = subject
+        else:
+            headers = {
+                name.lower(): value
+                for name, value in reply_to.headers.items()
+            }
+            message_id = headers.get('message-id')
+            if not reply_to.thread_id:
+                raise ValueError('reply_to must have a thread ID')
+            if not message_id:
+                raise ValueError('reply_to must have a Message-ID header')
+            if subject and subject != reply_to.subject:
+                raise ValueError('reply subject must match the original')
+            references = headers.get('references')
+            in_reply_to = headers.get('in-reply-to', '')
+            if not references and len(re.findall(
+                r'<[^<>]+@[^<>]+>', in_reply_to
+            )) == 1:
+                references = in_reply_to
+            msg['Subject'] = reply_to.subject
+            msg['In-Reply-To'] = message_id
+            msg['References'] = ' '.join(
+                value for value in (references, message_id) if value
+            )
 
         if cc:
             msg['Cc'] = ', '.join(cc)
@@ -1158,9 +1191,13 @@ class Gmail(object):
 
             self._ready_message_with_attachments(msg, attachments)
 
-        return {
+        message = {
             'raw': base64.urlsafe_b64encode(msg.as_string().encode()).decode()
         }
+        if reply_to is not None:
+            message['threadId'] = reply_to.thread_id
+
+        return message
 
     def _ready_message_with_attachments(
         self,

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -10,6 +10,7 @@ from googleapiclient.errors import HttpError
 
 from simplegmail import label
 from simplegmail.gmail import Gmail
+from simplegmail.message import Message
 
 
 def build_gmail():
@@ -37,6 +38,22 @@ def build_credentials(valid=True, expired=False, refresh_token='refresh'):
 def parse_message_resource(message_resource):
     return BytesParser(policy=policy.default).parsebytes(
         base64.urlsafe_b64decode(message_resource['raw'])
+    )
+
+
+def build_reply_to(headers, subject='Original subject', thread_id='thread-id'):
+    return Message(
+        service=MagicMock(),
+        creds=MagicMock(),
+        user_id='me',
+        msg_id='message-id',
+        thread_id=thread_id,
+        recipient='recipient@example.com',
+        sender='sender@example.com',
+        subject=subject,
+        date='date',
+        snippet='snippet',
+        headers=headers,
     )
 
 
@@ -259,6 +276,97 @@ def test_send_message_uses_existing_builder_and_shared_sender():
     assert result is sent_message
 
 
+@pytest.mark.parametrize(
+    ('headers', 'references'),
+    [
+        (
+            {'Message-ID': '<parent@example.com>'},
+            '<parent@example.com>',
+        ),
+        (
+            {
+                'Message-ID': '<parent@example.com>',
+                'In-Reply-To': '<grandparent@example.com>',
+            },
+            '<grandparent@example.com> <parent@example.com>',
+        ),
+        (
+            {
+                'message-id': '<parent@example.com>',
+                'references': '<first@example.com> <second@example.com>',
+                'in-reply-to': '<ignored@example.com>',
+            },
+            '<first@example.com> <second@example.com> <parent@example.com>',
+        ),
+        (
+            {
+                'Message-ID': '<parent@example.com>',
+                'In-Reply-To': '<first@example.com> <second@example.com>',
+            },
+            '<parent@example.com>',
+        ),
+    ],
+)
+def test_send_message_builds_threaded_reply(headers, references):
+    gmail = build_gmail()
+    sent_message = object()
+    gmail._send_message = MagicMock(return_value=sent_message)
+
+    result = gmail.send_message(
+        sender='me@example.com',
+        to='sender@example.com',
+        msg_plain='Reply body',
+        reply_to=build_reply_to(headers),
+    )
+
+    message_resource = gmail._send_message.call_args.args[0]
+    message = parse_message_resource(message_resource)
+    gmail._send_message.assert_called_once_with(message_resource, 'me')
+    assert message_resource['threadId'] == 'thread-id'
+    assert message['Subject'] == 'Original subject'
+    assert message['In-Reply-To'] == '<parent@example.com>'
+    assert message['References'] == references
+    assert message.get_body().get_content().strip() == 'Reply body'
+    assert result is sent_message
+
+
+@pytest.mark.parametrize(
+    ('reply_to', 'subject', 'error'),
+    [
+        (
+            build_reply_to(
+                {'Message-ID': '<parent@example.com>'}, thread_id=''
+            ),
+            '',
+            'reply_to must have a thread ID',
+        ),
+        (
+            build_reply_to({}),
+            '',
+            'reply_to must have a Message-ID header',
+        ),
+        (
+            build_reply_to({'Message-ID': '<parent@example.com>'}),
+            'Different subject',
+            'reply subject must match',
+        ),
+    ],
+)
+def test_send_message_rejects_invalid_reply(reply_to, subject, error):
+    gmail = build_gmail()
+    gmail._send_message = MagicMock()
+
+    with pytest.raises(ValueError, match=error):
+        gmail.send_message(
+            sender='me@example.com',
+            to='sender@example.com',
+            subject=subject,
+            reply_to=reply_to,
+        )
+
+    gmail._send_message.assert_not_called()
+
+
 def test_send_email_message_encodes_and_sends_mime_message():
     gmail = build_gmail()
     gmail.creds.expired = False
@@ -404,13 +512,15 @@ def test_create_message_with_only_an_attachment_has_no_empty_body(tmp_path):
 def test_create_message_without_attachments_remains_multipart_alternative():
     gmail = build_gmail()
 
-    message = parse_message_resource(gmail._create_message(
+    message_resource = gmail._create_message(
         sender='sender@example.com',
         to='recipient@example.com',
         msg_plain='Plain body',
         msg_html='<p>HTML body</p>',
-    ))
+    )
+    message = parse_message_resource(message_resource)
 
+    assert set(message_resource) == {'raw'}
     assert message.get_content_type() == 'multipart/alternative'
     assert [part.get_content_type() for part in message.get_payload()] == [
         'text/plain',


### PR DESCRIPTION
- add optional `reply_to` support to `Gmail.send_message()`
- include the Gmail `threadId` and RFC-compliant `In-Reply-To` and `References` headers
- reject incomplete reply metadata and explicitly mismatched subjects
- document threaded replies in the README

Existing message sending remains unchanged when `reply_to` is not provided.

Closes #44