### PR TITLE
[cleanup] Prepare for release of 5.0.0

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,12 +12,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: setup.py
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ significantly safer and avoids clashing with Google's many security measures.
 
 ## Installation
 
-Install using `pip` (Python3).
+Python 3.10 or newer is required. Install using `pip`:
 
 ```bash
 pip3 install simplegmail

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,16 @@ import setuptools
 
 setuptools.setup(
     name="simplegmail",
-    version="4.1.1",
+    version="5.0.0",
     url="https://github.com/jeremyephron/simplegmail",
     author="Jeremy Ephron",
     author_email="jeremye@cs.stanford.edu",
     description="A simple Python API client for Gmail.",
+    license="MIT",
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     packages=setuptools.find_packages(),
+    python_requires='>=3.10',
     install_requires=[
         'google-api-python-client>=1.7.3',
         'google-auth>=2.15.0',
@@ -25,8 +27,11 @@ setuptools.setup(
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        "License :: OSI Approved :: MIT License",
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         "Operating System :: OS Independent",
     ],
 )

--- a/simplegmail/gmail.py
+++ b/simplegmail/gmail.py
@@ -320,11 +320,10 @@ class Gmail(object):
 
         """
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.INBOX)
-        return self.get_unread_messages(user_id, labels, query)
+        labels = list(labels or []) + [label.INBOX]
+        return self.get_unread_messages(
+            user_id, labels, query, attachments
+        )
 
     def get_starred_messages(
         self,
@@ -358,10 +357,7 @@ class Gmail(object):
 
         """
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.STARRED)
+        labels = list(labels or []) + [label.STARRED]
         return self.get_messages(user_id, labels, query, attachments,
                                  include_spam_trash)
 
@@ -397,10 +393,7 @@ class Gmail(object):
 
         """
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.IMPORTANT)
+        labels = list(labels or []) + [label.IMPORTANT]
         return self.get_messages(user_id, labels, query, attachments,
                                  include_spam_trash)
 
@@ -436,10 +429,7 @@ class Gmail(object):
 
         """
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.UNREAD)
+        labels = list(labels or []) + [label.UNREAD]
         return self.get_messages(user_id, labels, query, attachments,
                                  include_spam_trash)
 
@@ -475,10 +465,7 @@ class Gmail(object):
 
         """
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.DRAFT)
+        labels = list(labels or []) + [label.DRAFT]
         return self.get_messages(user_id, labels, query, attachments,
                                  include_spam_trash)
 
@@ -514,10 +501,7 @@ class Gmail(object):
 
         """
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.SENT)
+        labels = list(labels or []) + [label.SENT]
         return self.get_messages(user_id, labels, query, attachments,
                                  include_spam_trash)
 
@@ -552,10 +536,7 @@ class Gmail(object):
 
         """
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.TRASH)
+        labels = list(labels or []) + [label.TRASH]
         return self.get_messages(user_id, labels, query, attachments, True)
 
     def get_spam_messages(
@@ -589,10 +570,7 @@ class Gmail(object):
         """
 
 
-        if labels is None:
-            labels = []
-
-        labels.append(label.SPAM)
+        labels = list(labels or []) + [label.SPAM]
         return self.get_messages(user_id, labels, query, attachments, True)
 
     def get_messages(
@@ -628,7 +606,8 @@ class Gmail(object):
             A list of message objects.
 
         Raises:
-            ValueError: `max_results` is not a positive integer.
+            ValueError: `attachments` is invalid or `max_results` is not a
+                positive integer.
             googleapiclient.errors.HttpError: There was an error executing the
                 HTTP request.
 
@@ -636,6 +615,10 @@ class Gmail(object):
 
         if labels is None:
             labels = []
+        if attachments not in ('ignore', 'reference', 'download'):
+            raise ValueError(
+                "attachments must be 'ignore', 'reference', or 'download'"
+            )
         if max_results is not None and (
             isinstance(max_results, bool)
             or not isinstance(max_results, int)

--- a/tests/test_gmail.py
+++ b/tests/test_gmail.py
@@ -528,6 +528,54 @@ def test_create_message_without_attachments_remains_multipart_alternative():
     ]
 
 
+@pytest.mark.parametrize(
+    ('method_name', 'required_labels', 'include_spam_trash'),
+    [
+        ('get_unread_inbox', [label.INBOX, label.UNREAD], False),
+        ('get_starred_messages', [label.STARRED], False),
+        ('get_important_messages', [label.IMPORTANT], False),
+        ('get_unread_messages', [label.UNREAD], False),
+        ('get_drafts', [label.DRAFT], False),
+        ('get_sent_messages', [label.SENT], False),
+        ('get_trash_messages', [label.TRASH], True),
+        ('get_spam_messages', [label.SPAM], True),
+    ],
+)
+def test_filtered_getters_forward_options_without_mutating_labels(
+    method_name, required_labels, include_spam_trash
+):
+    gmail = build_gmail()
+    gmail.get_messages = MagicMock(return_value=[])
+    labels = [label.PERSONAL]
+
+    result = getattr(gmail, method_name)(
+        labels=labels,
+        query='query',
+        attachments='ignore',
+    )
+
+    assert result == []
+    assert labels == [label.PERSONAL]
+    gmail.get_messages.assert_called_once_with(
+        'me',
+        [label.PERSONAL] + required_labels,
+        'query',
+        'ignore',
+        include_spam_trash,
+    )
+
+
+@pytest.mark.parametrize('attachments', [None, '', 'references', True])
+def test_get_messages_rejects_invalid_attachment_mode(attachments):
+    gmail = build_gmail()
+    gmail._service = MagicMock()
+
+    with pytest.raises(ValueError, match='attachments must be'):
+        gmail.get_messages(attachments=attachments)
+
+    gmail._service.users.assert_not_called()
+
+
 def test_get_messages_passes_metadata_option_to_message_retrieval():
     gmail = build_gmail()
     gmail.creds.expired = False


### PR DESCRIPTION
- Fixed get_unread_inbox() to forward its attachments argument.
- Prevented all filtered getters from mutating caller-owned label lists.
- Invalid attachment modes now raise ValueError before making API requests.
- Updated package version to 5.0.0.
- Declared Python 3.10+ support and updated classifiers.
- Expanded CI to Python 3.10–3.14.
- Replaced the deprecated license classifier with SPDX metadata.
- Updated installation documentation.